### PR TITLE
Python 3: fix aexpect-helper

### DIFF
--- a/aexpect/utils/path.py
+++ b/aexpect/utils/path.py
@@ -41,13 +41,15 @@ def find_command(cmd, default=None):
     :raise: :class:`aexpect.utils.path.CmdNotFoundError` in case the
             command was not found and no default was given.
     """
-    common_bin_paths = ["/usr/libexec", "/usr/local/sbin", "/usr/local/bin",
-                        "/usr/sbin", "/usr/bin", "/sbin", "/bin"]
     try:
         path_paths = os.environ['PATH'].split(":")
     except IndexError:
         path_paths = []
-    path_paths = list(set(common_bin_paths + path_paths))
+
+    for common_path in ["/usr/libexec", "/usr/local/sbin", "/usr/local/bin",
+                        "/usr/sbin", "/usr/bin", "/sbin", "/bin"]:
+        if common_path not in path_paths:
+            path_paths.append(common_path)
 
     for dir_path in path_paths:
         cmd_path = os.path.join(dir_path, cmd)

--- a/scripts/aexpect-helper
+++ b/scripts/aexpect-helper
@@ -99,7 +99,7 @@ if __name__ == "__main__":
         makestandard(shell_fd, echo)
 
         server_log.info('Opening output file %s' % output_filename)
-        output_file = open(output_filename, "w")
+        output_file = open(output_filename, "wb")
         server_log.info('Opening input pipe %s' % inpipe_filename)
         os.mkfifo(inpipe_filename)
         inpipe_fd = os.open(inpipe_filename, os.O_RDWR)
@@ -124,7 +124,7 @@ if __name__ == "__main__":
         sys.stdout.flush()
 
         # Initialize buffers
-        buffers = ["" for reader in readers]
+        buffers = [b"" for reader in readers]
 
         # Read from child and write to files/pipes
         server_log.info('Entering main read loop')
@@ -153,12 +153,12 @@ if __name__ == "__main__":
                 try:
                     data = os.read(shell_fd, 16384)
                 except OSError:
-                    data = ""
+                    data = b""
                 if not data:
                     check_termination = True
                 # Remove carriage returns from the data -- they often cause
                 # trouble and are normally not needed
-                data = data.replace("\r", "")
+                data = data.replace(b"\r", b"")
                 output_file.write(data)
                 output_file.flush()
                 for i in range(len(readers)):

--- a/scripts/aexpect-helper
+++ b/scripts/aexpect-helper
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This collection of fixes makes aexpect-helper work correctly on Python 3.

This was tested with Avocado's Docker runner plugin on a Python 3 environment.