### PR TITLE
Add (Travis) CI checks on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
 
 python:
-    - "2.7"
     - "2.6"
+    - "2.7"
+    - "3.4"
 
 sudo: false
 


### PR DESCRIPTION
This is the most basic way of making sure aexpect is Python 3 compatible.

Other types of testing should follow in the future though, and not
only for Python 3 (including unittests, functional tests and
integration tests).

Signed-off-by: Cleber Rosa <crosa@redhat.com>