### PR TITLE
Update to install/use python version specific helper script

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -17,6 +17,7 @@ API used to run/control interactive processes.
 import time
 import signal
 import os
+import sys
 import re
 import threading
 import shutil
@@ -166,7 +167,15 @@ class Spawn(object):
 
         # Start the server (which runs the command)
         if command:
-            helper_cmd = utils_path.find_command('aexpect-helper')
+            # try to find python specific version of aexpect-helper first, then
+            # try unversioned
+            helper_noversion = 'aexpect-helper'
+            helper_versioned = '{0}-{1.major}.{1.minor}'.format(
+                helper_noversion, sys.version_info)
+            try:
+                helper_cmd = utils_path.find_command(helper_versioned)
+            except utils_path.CmdNotFoundError:
+                helper_cmd = utils_path.find_command(helper_noversion)
             sub = subprocess.Popen([helper_cmd],
                                    shell=True,
                                    stdin=subprocess.PIPE,

--- a/python-aexpect.spec
+++ b/python-aexpect.spec
@@ -34,11 +34,12 @@ sftp, telnet, among others.
 
 %install
 %{__python} setup.py install --root %{buildroot} --skip-build
+mv %{buildroot}%{_bindir}/aexpect-helper %{buildroot}%{_bindir}/aexpect-helper-%{python_version}
 
 %files
 %defattr(-,root,root,-)
 %{python_sitelib}/aexpect*
-%{_bindir}/aexpect-helper
+%{_bindir}/aexpect-helper-*
 
 %changelog
 * Mon Apr 3 2017 Lucas Meneghel Rodrigues <lookkas@gmail.com> - 1.4.0-1


### PR DESCRIPTION
These minor changes should allow both py2 and py3 specific versions of the aexpect helper to be built and installed at the same time without conflicting.

Is there anything external to this package that uses the `aexpect-helper` script?

Would it be OK to simplify this change further and skip having the client code fall back to finding an unversioned helper?