### PR TITLE
RPM Packaging: sync with Fedora/EPEL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ all:
 	@echo "RPM related targets:"
 	@echo "make srpm: Generate a source RPM package (.srpm)"
 	@echo "make rpm: Generate binary RPMs"
+	@echo
+	@echo "Release related targets:"
+	@echo "source-release:     Create source package for the latest tagged release"
+	@echo "srpm-release:       Generate a source RPM package (.srpm) for the latest tagged release"
+	@echo "rpm-release:        Generate binary RPMs for the latest tagged release"
 
 source: clean
 	if test ! -d SOURCES; then mkdir SOURCES; fi
@@ -52,11 +57,19 @@ build-deb-all: prepare-source
 
 srpm: source
 	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
-	mock --old-chroot -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --buildsrpm --spec python-aexpect.spec --sources SOURCES
+	mock --old-chroot -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --buildsrpm --spec python-aexpect.spec --sources SOURCES
 
 rpm: srpm
 	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
-	mock --old-chroot -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --rebuild BUILD/SRPM/python-aexpect-$(VERSION)-*.src.rpm
+	mock --old-chroot -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --rebuild BUILD/SRPM/python-aexpect-$(VERSION)-*.src.rpm
+
+srpm-release: source-release
+	if test ! -d BUILD/SRPM; then mkdir -p BUILD/SRPM; fi
+	mock --old-chroot -r $(MOCK_CONFIG) --resultdir BUILD/SRPM -D "rel_build 1" --buildsrpm --spec python-aexpect.spec --sources SOURCES
+
+rpm-release: srpm-release
+	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
+	mock --old-chroot -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/python-aexpect-$(VERSION)-*.src.rpm
 
 check:
 	inspekt checkall

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ all:
 	@echo "make build-deb-all - Generate both source and binary debian packages"
 	@echo "make build-rpm-src - Generate a source RPM package (.srpm)"
 	@echo "make build-rpm-all - Generate both source and binary RPMs"
-	@echo "make man - Generate the avocado man page"
 	@echo "make check - Runs tree static check, unittests and functional tests"
 	@echo "make clean - Get rid of scratch and byte files"
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ DESTDIR=/
 BUILDIR=$(CURDIR)/debian/aexpect
 PROJECT=aexpect
 VERSION="1.4.0"
+COMMIT=$(shell git log --pretty=format:'%H' -n 1)
+SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1)
 
 all:
 	@echo "make check - Runs tree static check, unittests and functional tests"
@@ -16,8 +18,13 @@ all:
 	@echo "make srpm: Generate a source RPM package (.srpm)"
 	@echo "make rpm: Generate binary RPMs"
 
-source:
-	$(PYTHON) setup.py sdist $(COMPILE) --dist-dir=SOURCES
+source: clean
+	if test ! -d SOURCES; then mkdir SOURCES; fi
+	git archive --prefix="aexpect-$(COMMIT)/" -o "SOURCES/aexpect-$(SHORT_COMMIT).tar.gz" HEAD
+
+source-release: clean
+	if test ! -d SOURCES; then mkdir SOURCES; fi
+	git archive --prefix="aexpect-$(VERSION)/" -o "SOURCES/aexpect-$(VERSION).tar.gz" $(VERSION)
 
 install:
 	$(PYTHON) setup.py install --root $(DESTDIR) $(COMPILE)

--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,16 @@ PROJECT=aexpect
 VERSION="1.4.0"
 
 all:
+	@echo "make check - Runs tree static check, unittests and functional tests"
+	@echo "make clean - Get rid of scratch and byte files"
 	@echo "make source - Create source package"
 	@echo "make install - Install on local system"
 	@echo "make build-deb-src - Generate a source debian package"
 	@echo "make build-deb-bin - Generate a binary debian package"
 	@echo "make build-deb-all - Generate both source and binary debian packages"
-	@echo "make build-rpm-src - Generate a source RPM package (.srpm)"
-	@echo "make build-rpm-all - Generate both source and binary RPMs"
-	@echo "make check - Runs tree static check, unittests and functional tests"
-	@echo "make clean - Get rid of scratch and byte files"
+	@echo "RPM related targets:"
+	@echo "make srpm: Generate a source RPM package (.srpm)"
+	@echo "make rpm: Generate binary RPMs"
 
 source:
 	$(PYTHON) setup.py sdist $(COMPILE) --dist-dir=SOURCES
@@ -40,11 +41,11 @@ build-deb-all: prepare-source
 	# build both source and binary packages
 	dpkg-buildpackage -i -I -rfakeroot
 
-build-rpm-src: source
+srpm: source
 	rpmbuild --define '_topdir %{getenv:PWD}' \
 		 -bs python-aexpect.spec
 
-build-rpm-all: source
+rpm: source
 	rpmbuild --define '_topdir %{getenv:PWD}' \
 		 -ba python-aexpect.spec
 

--- a/python-aexpect.spec
+++ b/python-aexpect.spec
@@ -20,6 +20,9 @@
 %global gittar		%{srcname}-%{shortcommit}.tar.gz
 %endif
 
+# Selftests are provided but skipped because they use unsupported tooling.
+%global with_tests 0
+
 Name: python-%{srcname}
 Version: 1.4.0
 Release: 2%{?gitrel}%{?dist}
@@ -57,6 +60,11 @@ sftp, telnet, among others.
 %install
 %{__python} setup.py install --root %{buildroot} --skip-build
 
+%check
+%if %{with_tests}
+selftests/checkall
+%endif
+
 %files
 %defattr(-,root,root,-)
 %{python_sitelib}/aexpect*
@@ -69,6 +77,7 @@ sftp, telnet, among others.
 - Added released version builds
 - Remove compatiblity with older package name
 - Reordered tags
+- Added conditional for check target
 
 * Mon Apr 3 2017 Lucas Meneghel Rodrigues <lookkas@gmail.com> - 1.4.0-1
 - Upgrade to upstream version 1.4.0

--- a/python-aexpect.spec
+++ b/python-aexpect.spec
@@ -1,6 +1,14 @@
 %global srcname aexpect
 
+# Conditional for release vs. snapshot builds. Set to 1 for release build.
+%if ! 0%{?rel_build:1}
+    %global rel_build 1
+%endif
+
 # Settings used for build from snapshots.
+%if 0%{?rel_build}
+%global gittar		%{srcname}-%{version}.tar.gz
+%else
 %if ! 0%{?commit:1}
 %global commit		7597f77853fc668d640b3652a25aa57a515742fa
 %endif
@@ -10,6 +18,7 @@
 %global shortcommit	%(c=%{commit};echo ${c:0:7})
 %global gitrel		.%{commit_date}git%{shortcommit}
 %global gittar		%{srcname}-%{shortcommit}.tar.gz
+%endif
 
 Summary: Aexpect is a python library to control interactive applications
 Name: python-%{srcname}
@@ -18,7 +27,13 @@ Release: 2%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: https://github.com/avocado-framework/aexpect
+
+%if 0%{?rel_build}
+Source0: https://github.com/avocado-framework/%{srcname}/archive/%{version}.tar.gz#/%{gittar}
+%else
 Source0: https://github.com/avocado-framework/%{srcname}/archive/%{commit}.tar.gz#/%{gittar}
+%endif
+
 BuildArch: noarch
 Requires: python
 BuildRequires: python, python-setuptools
@@ -38,7 +53,11 @@ similar to pexpect. You can use it to control applications such as ssh, scp
 sftp, telnet, among others.
 
 %prep
-%setup -q -n %{srcname}-%{commit}
+%if 0%{?rel_build}
+%autosetup -n %{srcname}-%{version}
+%else
+%autosetup -n %{srcname}-%{commit}
+%endif
 
 %build
 %{__python} setup.py build
@@ -55,6 +74,7 @@ sftp, telnet, among others.
 * Wed Mar 14 2018 Cleber Rosa <cleber@redhat.com> - 1.4.0-2
 - Changed URL to aexpect repo
 - Changed build to use a git archived based source
+- Added released version builds
 
 * Mon Apr 3 2017 Lucas Meneghel Rodrigues <lookkas@gmail.com> - 1.4.0-1
 - Upgrade to upstream version 1.4.0

--- a/python-aexpect.spec
+++ b/python-aexpect.spec
@@ -20,12 +20,13 @@
 %global gittar		%{srcname}-%{shortcommit}.tar.gz
 %endif
 
-Summary: Aexpect is a python library to control interactive applications
 Name: python-%{srcname}
 Version: 1.4.0
 Release: 2%{?gitrel}%{?dist}
-License: GPLv2
+Summary: Aexpect is a python library to control interactive applications
 Group: Development/Tools
+
+License: GPLv2
 URL: https://github.com/avocado-framework/aexpect
 
 %if 0%{?rel_build}
@@ -67,6 +68,7 @@ sftp, telnet, among others.
 - Changed build to use a git archived based source
 - Added released version builds
 - Remove compatiblity with older package name
+- Reordered tags
 
 * Mon Apr 3 2017 Lucas Meneghel Rodrigues <lookkas@gmail.com> - 1.4.0-1
 - Upgrade to upstream version 1.4.0

--- a/python-aexpect.spec
+++ b/python-aexpect.spec
@@ -23,6 +23,12 @@
 # Selftests are provided but skipped because they use unsupported tooling.
 %global with_tests 0
 
+%if 0%{?rhel}
+%global with_python3 0
+%else
+%global with_python3 1
+%endif
+
 Name: python-%{srcname}
 Version: 1.4.0
 Release: 2%{?gitrel}%{?dist}
@@ -40,7 +46,12 @@ Source0: https://github.com/avocado-framework/%{srcname}/archive/%{commit}.tar.g
 
 BuildArch: noarch
 Requires: python
-BuildRequires: python
+BuildRequires: python2-devel
+
+%if %{with_python3}
+Requires: python3
+BuildRequires: python3-devel
+%endif
 
 %if 0%{?rhel}
 BuildRequires: python-setuptools
@@ -51,6 +62,27 @@ Aexpect is a python library used to control interactive applications, very
 similar to pexpect. You can use it to control applications such as ssh, scp
 sftp, telnet, among others.
 
+%package -n python2-%{srcname}
+Summary: %{summary}
+%{?python_provide:%python_provide python2-%{srcname}}
+
+%description -n python2-%{srcname}
+Aexpect is a python library used to control interactive applications, very
+similar to pexpect. You can use it to control applications such as ssh, scp
+sftp, telnet, among others.
+
+%if %{with_python3}
+%package -n python%{python3_pkgversion}-%{srcname}
+Summary: %{summary}
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+
+%description -n python%{python3_pkgversion}-%{srcname}
+Aexpect is a python library used to control interactive applications, very
+similar to pexpect. You can use it to control applications such as ssh, scp
+sftp, telnet, among others.
+PYTHON 3 SUPPORT IS CURRENTLY EXPERIMENTAL
+%endif
+
 %prep
 %if 0%{?rel_build}
 %autosetup -n %{srcname}-%{version}
@@ -59,20 +91,48 @@ sftp, telnet, among others.
 %endif
 
 %build
-%{__python} setup.py build
+%py2_build
+
+%if %{with_python3}
+%py3_build
+%endif
 
 %install
-%{__python} setup.py install --root %{buildroot} --skip-build
+%py2_install
+# move and symlink python2 version-specific executables
+mv %{buildroot}%{_bindir}/aexpect-helper %{buildroot}%{_bindir}/aexpect-helper-%{python2_version}
+ln -s aexpect-helper-%{python2_version} %{buildroot}%{_bindir}/aexpect-helper-2
+
+%if %{with_python3}
+%py3_install
+mv %{buildroot}%{_bindir}/aexpect-helper %{buildroot}%{_bindir}/aexpect-helper-%{python3_version}
+ln -s aexpect-helper-%{python3_version} %{buildroot}%{_bindir}/aexpect-helper-3
+%endif
+
+# use python2 for unversioned executable
+ln -s aexpect-helper-%{python2_version} %{buildroot}%{_bindir}/aexpect-helper
 
 %check
 %if %{with_tests}
 selftests/checkall
 %endif
 
-%files
-%defattr(-,root,root,-)
-%{python_sitelib}/aexpect*
+%files -n python2-%{srcname}
+%license LICENSE
+%doc README.rst
+%{python2_sitelib}/aexpect/
+%{python2_sitelib}/aexpect-%{version}-py%{python2_version}.egg-info
 %{_bindir}/aexpect-helper
+%{_bindir}/aexpect-helper-2*
+
+%if %{with_python3}
+%files -n python%{python3_pkgversion}-%{srcname}
+%license LICENSE
+%doc README.rst
+%{python3_sitelib}/aexpect/
+%{python3_sitelib}/aexpect-%{version}-py%{python3_version}.egg-info
+%{_bindir}/aexpect-helper-3*
+%endif
 
 %changelog
 * Wed Mar 14 2018 Cleber Rosa <cleber@redhat.com> - 1.4.0-2
@@ -83,6 +143,7 @@ selftests/checkall
 - Reordered tags
 - Added conditional for check target
 - Only require python-setuptools on RHEL
+- Added rules for also building Python 3 packages
 
 * Mon Apr 3 2017 Lucas Meneghel Rodrigues <lookkas@gmail.com> - 1.4.0-1
 - Upgrade to upstream version 1.4.0

--- a/python-aexpect.spec
+++ b/python-aexpect.spec
@@ -38,15 +38,6 @@ BuildArch: noarch
 Requires: python
 BuildRequires: python, python-setuptools
 
-# For compatibility reasons, let's mark this package as one that
-# provides the same functionality as the old package name and also
-# one that obsoletes the old package name, so that the new name is
-# favored.  These could (and should) be removed in the future.
-# These changes are backed by the following guidelines:
-# https://fedoraproject.org/wiki/Upgrade_paths_%E2%80%94_renaming_or_splitting_packages
-Obsoletes: %{srcname} < 1.3.1-1
-Provides: %{srcname} = %{version}-%{release}
-
 %description
 Aexpect is a python library used to control interactive applications, very
 similar to pexpect. You can use it to control applications such as ssh, scp
@@ -75,6 +66,7 @@ sftp, telnet, among others.
 - Changed URL to aexpect repo
 - Changed build to use a git archived based source
 - Added released version builds
+- Remove compatiblity with older package name
 
 * Mon Apr 3 2017 Lucas Meneghel Rodrigues <lookkas@gmail.com> - 1.4.0-1
 - Upgrade to upstream version 1.4.0

--- a/python-aexpect.spec
+++ b/python-aexpect.spec
@@ -1,13 +1,24 @@
 %global srcname aexpect
 
+# Settings used for build from snapshots.
+%if ! 0%{?commit:1}
+%global commit		7597f77853fc668d640b3652a25aa57a515742fa
+%endif
+%if ! 0%{?commit_date:1}
+%global commit_date	20180202
+%endif
+%global shortcommit	%(c=%{commit};echo ${c:0:7})
+%global gitrel		.%{commit_date}git%{shortcommit}
+%global gittar		%{srcname}-%{shortcommit}.tar.gz
+
 Summary: Aexpect is a python library to control interactive applications
 Name: python-%{srcname}
 Version: 1.4.0
-Release: 2%{?dist}
+Release: 2%{?gitrel}%{?dist}
 License: GPLv2
 Group: Development/Tools
 URL: https://github.com/avocado-framework/aexpect
-Source: %{srcname}-%{version}.tar.gz
+Source0: https://github.com/avocado-framework/%{srcname}/archive/%{commit}.tar.gz#/%{gittar}
 BuildArch: noarch
 Requires: python
 BuildRequires: python, python-setuptools
@@ -27,7 +38,7 @@ similar to pexpect. You can use it to control applications such as ssh, scp
 sftp, telnet, among others.
 
 %prep
-%setup -q -n %{srcname}-%{version}
+%setup -q -n %{srcname}-%{commit}
 
 %build
 %{__python} setup.py build
@@ -43,6 +54,7 @@ sftp, telnet, among others.
 %changelog
 * Wed Mar 14 2018 Cleber Rosa <cleber@redhat.com> - 1.4.0-2
 - Changed URL to aexpect repo
+- Changed build to use a git archived based source
 
 * Mon Apr 3 2017 Lucas Meneghel Rodrigues <lookkas@gmail.com> - 1.4.0-1
 - Upgrade to upstream version 1.4.0

--- a/python-aexpect.spec
+++ b/python-aexpect.spec
@@ -40,7 +40,11 @@ Source0: https://github.com/avocado-framework/%{srcname}/archive/%{commit}.tar.g
 
 BuildArch: noarch
 Requires: python
-BuildRequires: python, python-setuptools
+BuildRequires: python
+
+%if 0%{?rhel}
+BuildRequires: python-setuptools
+%endif
 
 %description
 Aexpect is a python library used to control interactive applications, very
@@ -78,6 +82,7 @@ selftests/checkall
 - Remove compatiblity with older package name
 - Reordered tags
 - Added conditional for check target
+- Only require python-setuptools on RHEL
 
 * Mon Apr 3 2017 Lucas Meneghel Rodrigues <lookkas@gmail.com> - 1.4.0-1
 - Upgrade to upstream version 1.4.0

--- a/python-aexpect.spec
+++ b/python-aexpect.spec
@@ -3,10 +3,10 @@
 Summary: Aexpect is a python library to control interactive applications
 Name: python-%{srcname}
 Version: 1.4.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPLv2
 Group: Development/Tools
-URL: http://avocado-framework.readthedocs.org/
+URL: https://github.com/avocado-framework/aexpect
 Source: %{srcname}-%{version}.tar.gz
 BuildArch: noarch
 Requires: python
@@ -41,6 +41,9 @@ sftp, telnet, among others.
 %{_bindir}/aexpect-helper
 
 %changelog
+* Wed Mar 14 2018 Cleber Rosa <cleber@redhat.com> - 1.4.0-2
+- Changed URL to aexpect repo
+
 * Mon Apr 3 2017 Lucas Meneghel Rodrigues <lookkas@gmail.com> - 1.4.0-1
 - Upgrade to upstream version 1.4.0
 


### PR DESCRIPTION
Let's make upstream SPEC file more in sync with what's on Fedora/EPEL and Makefile similar to Avocado's.