### PR TITLE
Stype check: fix W605 failures

### DIFF
--- a/aexpect/utils/astring.py
+++ b/aexpect/utils/astring.py
@@ -33,8 +33,8 @@ def strip_console_codes(output, custom_codes=None):
     return_str = ""
     index = 0
     output = "\x1b[m%s" % output
-    console_codes = "%[G@8]|\[[@A-HJ-MPXa-hl-nqrsu\`]"
-    console_codes += "|\[[\d;]+[HJKgqnrm]|#8|\([B0UK]|\)"
+    console_codes = "%[G@8]|\\[[@A-HJ-MPXa-hl-nqrsu\\`]"
+    console_codes += "|\\[[\\d;]+[HJKgqnrm]|#8|\\([B0UK]|\\)"
     if custom_codes is not None and custom_codes not in console_codes:
         console_codes += "|%s" % custom_codes
     while index < len(output):

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,1 +1,2 @@
+pycodestyle==2.4.0
 inspektor==0.4.5


### PR DESCRIPTION
Similar to what happened in Avocado (https://github.com/avocado-framework/avocado/pull/2574), this fixes the new W605 checks on new pycodestyle. 