### PR TITLE
Tests: add a basic client/Spawn test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-PYTHON=`which python`
+PYTHON=$(shell which python 2>/dev/null || which python3 2>/dev/null)
+PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)
 DESTDIR=/
 BUILDIR=$(CURDIR)/debian/aexpect
 PROJECT=aexpect
@@ -49,8 +50,10 @@ build-rpm-all: source
 	rpmbuild --define '_topdir %{getenv:PWD}' \
 		 -ba python-aexpect.spec
 
-check:
+check: clean
 	inspekt checkall
+	$(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS)
+	$(PYTHON) setup.py test
 
 clean:
 	$(PYTHON) setup.py clean

--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -170,8 +170,9 @@ class Spawn(object):
             # try to find python specific version of aexpect-helper first, then
             # try unversioned
             helper_noversion = 'aexpect-helper'
-            helper_versioned = '{0}-{1.major}.{1.minor}'.format(
-                helper_noversion, sys.version_info)
+            helper_versioned = '{0}-{1}.{2}'.format(helper_noversion,
+                                                    sys.version_info[0],
+                                                    sys.version_info[1])
             try:
                 helper_cmd = utils_path.find_command(helper_versioned)
             except utils_path.CmdNotFoundError:

--- a/setup.py
+++ b/setup.py
@@ -59,4 +59,5 @@ if __name__ == '__main__':
           packages=['aexpect',
                     'aexpect.utils'],
           scripts=['scripts/aexpect-helper'],
+          test_suite='tests',
           use_2to3=True)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,54 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2018
+# Author: Cleber Rosa <crosa@redhat.com>
+
+import os
+import sys
+import time
+import unittest
+
+from aexpect import client
+
+
+SLEEP = 0.2
+
+
+class ClientTest(unittest.TestCase):
+
+    def test_client_spawn_python(self):
+        """
+        Tests the basic spawning of an interactive process
+
+        This test uses the Python interpreter itself, and to make sure
+        lines sent are effective, python code that creates a temporary
+        file is send to the interpreter and checked by the test.
+
+        The sending of lines is not synchronous to their execution, so
+        some level of wait is necessary for somewhat reliable results.
+        """
+        python = client.Spawn(sys.executable)
+        self.assertTrue(python.is_alive())
+        # it may take some time for the process to start **and**
+        # produce output
+        python.sendline("import tempfile")
+        python.sendline("tempfile.mkstemp()")
+        time.sleep(SLEEP)
+        lines = python.get_output().splitlines()
+        # this line should look like: ">>> >>> (5, '/tmp/tmpxxxx')"
+        _, tempfile_quote = lines[-2][9:-1].split(' ', 1)
+        tempfile = tempfile_quote[1:-1]
+        self.assertTrue(os.path.exists(tempfile))
+        python.sendline("import os")
+        python.sendline("os.unlink('%s')" % tempfile)
+        time.sleep(SLEEP)
+        self.assertFalse(os.path.exists(tempfile))


### PR DESCRIPTION
And the very minimum test infrastructure.  This should allow one
to run the tests by doing the classical:

 $ python setup.py test

And of course can and will be extended/enabled on `make check`,
Travis-CI, etc.

Signed-off-by: Cleber Rosa <crosa@redhat.com>