### PR TITLE
Encoding selection: use Python's locale module for choosing it

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -14,16 +14,17 @@ API used to run/control interactive processes.
 
 :copyright: 2008-2015 Red Hat Inc.
 """
-import time
-import signal
-import os
-import sys
-import re
-import threading
-import shutil
-import select
+import locale
 import logging
+import os
+import re
+import select
+import shutil
+import signal
 import subprocess
+import sys
+import threading
+import time
 
 from aexpect.exceptions import ExpectError
 from aexpect.exceptions import ExpectProcessTerminatedError
@@ -123,9 +124,9 @@ class Spawn(object):
         self.a_id = a_id or data_factory.generate_random_string(8)
         self.log_file = None
         self.closed = False
-        # Use PYTHONENCODING or utf-8 (instead of ascii)
-        self.encoding = os.environ.get("PYTHONENCODING", "utf-8")
-
+        self.encoding = locale.getpreferredencoding()
+        if self.encoding is None:
+            self.encoding = "UTF-8"
         base_dir = os.path.join(BASE_DIR, 'aexpect_%s' % self.a_id)
 
         # Define filenames for communication with server


### PR DESCRIPTION
The current encoding selection makes reference to an environment
variable that has no meaning outside of aexpect itself, and it's not
documented to serve that purpose.  In fact, it was a misinterpretation
of a similarly named environment variable, PYTHONIOENCODING.

Let's use the Python's standard library `locale` for choosing the
default encoding.  Since that is a guess and may return None, let's
set "UTF-8" as a fallback.

Signed-off-by: Cleber Rosa <crosa@redhat.com>