### PR TITLE
To support fd passing [v2]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ all:
 	@echo "make clean - Get rid of scratch and byte files"
 	@echo "make source - Create source package"
 	@echo "make install - Install on local system"
+	@echo "make requirements - Install runtime requirements"
 	@echo "make build-deb-src - Generate a source debian package"
 	@echo "make build-deb-bin - Generate a binary debian package"
 	@echo "make build-deb-all - Generate both source and binary debian packages"
@@ -35,6 +36,13 @@ source-release: clean
 
 install:
 	$(PYTHON) setup.py install --root $(DESTDIR) $(COMPILE)
+
+pip:
+	$(PYTHON) -m pip --version || $(PYTHON) -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s' % (sys.executable, f))"
+
+requirements: pip
+	- pip install "pip>=6.0.1"
+	- pip install -r requirements.txt
 
 prepare-source:
 	# build the source package in the parent directory

--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -23,7 +23,7 @@ import threading
 import shutil
 import select
 import logging
-import subprocess
+import subprocess32 as subprocess
 
 from aexpect.exceptions import ExpectError
 from aexpect.exceptions import ExpectProcessTerminatedError
@@ -104,7 +104,7 @@ class Spawn(object):
     """
 
     def __init__(self, command=None, a_id=None, auto_close=False, echo=False,
-                 linesep="\n"):
+                 linesep="\n", pass_fds=()):
         """
         Initialize the class and run command as a child process.
 
@@ -119,6 +119,8 @@ class Spawn(object):
                 parameter has an effect only when starting a new server.
         :param linesep: Line separator to be appended to strings sent to the
                 child process by sendline().
+        :param pass_fds: Optional sequence of file descriptors to keep open
+                between the parent and child.
         """
         self.a_id = a_id or data_factory.generate_random_string(8)
         self.log_file = None
@@ -180,7 +182,8 @@ class Spawn(object):
                                    shell=True,
                                    stdin=subprocess.PIPE,
                                    stdout=subprocess.PIPE,
-                                   stderr=subprocess.STDOUT)
+                                   stderr=subprocess.STDOUT,
+                                   pass_fds=pass_fds)
             # Send parameters to the server
             sub.stdin.write(("%s\n" % self.a_id).encode(self.encoding))
             sub.stdin.write(("%s\n" % echo).encode(self.encoding))
@@ -452,7 +455,7 @@ class Tail(Spawn):
     def __init__(self, command=None, a_id=None, auto_close=False, echo=False,
                  linesep="\n", termination_func=None, termination_params=(),
                  output_func=None, output_params=(), output_prefix="",
-                 thread_name=None):
+                 thread_name=None, pass_fds=()):
         """
         Initialize the class and run command as a child process.
 
@@ -479,6 +482,8 @@ class Tail(Spawn):
                 output line.
         :param output_prefix: String to prepend to lines sent to output_func.
         :param thread_name: Name of thread to better identify hanging threads.
+        :param pass_fds: Optional sequence of file descriptors to keep open
+                between the parent and child.
         """
         # Add a reader and a close hook
         self._add_reader("tail")
@@ -486,7 +491,8 @@ class Tail(Spawn):
         self._add_close_hook(Tail._close_log_file)
 
         # Init the superclass
-        Spawn.__init__(self, command, a_id, auto_close, echo, linesep)
+        Spawn.__init__(self, command, a_id, auto_close, echo, linesep,
+                       pass_fds)
         if thread_name is None:
             self.thread_name = "tail_thread_%s_%s" % (self.a_id,
                                                       str(command)[:10])
@@ -669,7 +675,7 @@ class Expect(Tail):
     def __init__(self, command=None, a_id=None, auto_close=True, echo=False,
                  linesep="\n", termination_func=None, termination_params=(),
                  output_func=None, output_params=(), output_prefix="",
-                 thread_name=None):
+                 thread_name=None, pass_fds=()):
         """
         Initialize the class and run command as a child process.
 
@@ -695,6 +701,8 @@ class Expect(Tail):
         :param output_params: Parameters to send to output_func before the
                 output line.
         :param output_prefix: String to prepend to lines sent to output_func.
+        :param pass_fds: Optional sequence of file descriptors to keep open
+                between the parent and child.
         """
         # Add a reader
         self._add_reader("expect")
@@ -702,7 +710,8 @@ class Expect(Tail):
         # Init the superclass
         Tail.__init__(self, command, a_id, auto_close, echo, linesep,
                       termination_func, termination_params,
-                      output_func, output_params, output_prefix, thread_name)
+                      output_func, output_params, output_prefix, thread_name,
+                      pass_fds)
 
     def __reduce__(self):
         return self.__class__, (self.__getinitargs__())
@@ -945,7 +954,7 @@ class ShellSession(Expect):
                  linesep="\n", termination_func=None, termination_params=(),
                  output_func=None, output_params=(), output_prefix="",
                  thread_name=None, prompt=r"[\#\$]\s*$",
-                 status_test_command="echo $?"):
+                 status_test_command="echo $?", pass_fds=()):
         """
         Initialize the class and run command as a child process.
 
@@ -975,11 +984,14 @@ class ShellSession(Expect):
         :param status_test_command: Command to be used for getting the last
                 exit status of commands run inside the shell (used by
                 cmd_status_output() and friends).
+        :param pass_fds: Optional sequence of file descriptors to keep open
+                between the parent and child.
         """
         # Init the superclass
         Expect.__init__(self, command, a_id, auto_close, echo, linesep,
                         termination_func, termination_params,
-                        output_func, output_params, output_prefix, thread_name)
+                        output_func, output_params, output_prefix, thread_name,
+                        pass_fds)
 
         # Remember some attributes
         self.prompt = prompt
@@ -1289,7 +1301,7 @@ class ShellSession(Expect):
 
 
 def run_tail(command, termination_func=None, output_func=None, output_prefix="",
-             timeout=1.0, auto_close=True):
+             timeout=1.0, auto_close=True, pass_fds=()):
     """
     Run a subprocess in the background and collect its output and exit status.
 
@@ -1308,7 +1320,9 @@ def run_tail(command, termination_func=None, output_func=None, output_prefix="",
     :param timeout: Time duration (in seconds) to wait for the subprocess to
             terminate before returning
     :param auto_close: If True, close() the instance automatically when its
-                reference count drops to zero (default False).
+            reference count drops to zero (default False).
+    :param pass_fds: Optional sequence of file descriptors to keep open
+            between the parent and child.
 
     :return: A Expect object.
     """
@@ -1316,7 +1330,8 @@ def run_tail(command, termination_func=None, output_func=None, output_prefix="",
                       termination_func=termination_func,
                       output_func=output_func,
                       output_prefix=output_prefix,
-                      auto_close=auto_close)
+                      auto_close=auto_close,
+                      pass_fds=pass_fds)
 
     end_time = time.time() + timeout
     while time.time() < end_time and bg_process.is_alive():
@@ -1326,7 +1341,7 @@ def run_tail(command, termination_func=None, output_func=None, output_prefix="",
 
 
 def run_bg(command, termination_func=None, output_func=None, output_prefix="",
-           timeout=1.0, auto_close=True):
+           timeout=1.0, auto_close=True, pass_fds=()):
     """
     Run a subprocess in the background and collect its output and exit status.
 
@@ -1345,7 +1360,9 @@ def run_bg(command, termination_func=None, output_func=None, output_prefix="",
     :param timeout: Time duration (in seconds) to wait for the subprocess to
             terminate before returning
     :param auto_close: If True, close() the instance automatically when its
-                reference count drops to zero (default False).
+            reference count drops to zero (default False).
+    :param pass_fds: Optional sequence of file descriptors to keep open
+            between the parent and child.
 
     :return: A Expect object.
     """
@@ -1353,7 +1370,8 @@ def run_bg(command, termination_func=None, output_func=None, output_prefix="",
                         termination_func=termination_func,
                         output_func=output_func,
                         output_prefix=output_prefix,
-                        auto_close=auto_close)
+                        auto_close=auto_close,
+                        pass_fds=pass_fds)
 
     end_time = time.time() + timeout
     while time.time() < end_time and bg_process.is_alive():
@@ -1362,7 +1380,8 @@ def run_bg(command, termination_func=None, output_func=None, output_prefix="",
     return bg_process
 
 
-def run_fg(command, output_func=None, output_prefix="", timeout=1.0):
+def run_fg(command, output_func=None, output_prefix="", timeout=1.0,
+           pass_fds=()):
     """
     Run a subprocess in the foreground and collect its output and exit status.
 
@@ -1378,12 +1397,15 @@ def run_fg(command, output_func=None, output_prefix="", timeout=1.0):
             before passing it to stdout_func
     :param timeout: Time duration (in seconds) to wait for the subprocess to
             terminate before killing it and returning
+    :param pass_fds: Optional sequence of file descriptors to keep open
+            between the parent and child.
 
     :return: A 2-tuple containing the exit status of the process and its
             STDOUT/STDERR output.  If timeout expires before the process
             terminates, the returned status is None.
     """
-    bg_process = run_bg(command, None, output_func, output_prefix, timeout)
+    bg_process = run_bg(command, None, output_func, output_prefix, timeout,
+                        pass_fds=pass_fds)
     output = bg_process.get_output()
     if bg_process.is_alive():
         status = None

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,2 +1,3 @@
 pycodestyle==2.4.0
 inspektor==0.4.5
+subprocess32==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+subprocess32>=3.5.0

--- a/tests/test_pass_fds.py
+++ b/tests/test_pass_fds.py
@@ -1,0 +1,96 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2018
+# Author: Xu Han <xuhan@redhat.com>
+
+import time
+import unittest
+
+from aexpect import client
+
+
+SLEEP = 1
+
+DEVNULL = "/dev/null"
+LIST_FD_CMD = ('''python -c "import os; os.system('ls -l /proc/%d/fd' % '''
+               '''os.getpid())"''')
+
+
+class PassfdsTest(unittest.TestCase):
+
+    def test_pass_fds_spawn(self):
+        """
+        Tests fd passing for `client.Spawn`
+        """
+        with open(DEVNULL, "r") as devnull:
+            fd = devnull.fileno()
+
+            child = client.Spawn(LIST_FD_CMD)
+            time.sleep(SLEEP)
+            self.assertFalse(DEVNULL in child.get_output())
+            child.close()
+
+            child = client.Spawn(LIST_FD_CMD, pass_fds=[fd])
+            time.sleep(SLEEP)
+            self.assertTrue(DEVNULL in child.get_output())
+            child.close()
+
+    def test_pass_fds_tail(self):
+        """
+        Tests fd passing for `client.Tail`
+        """
+        with open(DEVNULL, "r") as devnull:
+            fd = devnull.fileno()
+
+            child = client.Tail(LIST_FD_CMD)
+            time.sleep(SLEEP)
+            self.assertFalse(DEVNULL in child.get_output())
+            child.close()
+
+            child = client.Tail(LIST_FD_CMD, pass_fds=[fd])
+            time.sleep(SLEEP)
+            self.assertTrue(DEVNULL in child.get_output())
+            child.close()
+
+    def test_pass_fds_expect(self):
+        """
+        Tests fd passing for `client.Expect`
+        """
+        with open(DEVNULL, "r") as devnull:
+            fd = devnull.fileno()
+
+            child = client.Expect(LIST_FD_CMD)
+            time.sleep(SLEEP)
+            self.assertFalse(DEVNULL in child.get_output())
+            child.close()
+
+            child = client.Expect(LIST_FD_CMD, pass_fds=[fd])
+            time.sleep(SLEEP)
+            self.assertTrue(DEVNULL in child.get_output())
+            child.close()
+
+    def test_pass_fds_session(self):
+        """
+        Tests fd passing for `client.ShellSession`
+        """
+        with open(DEVNULL, "r") as devnull:
+            fd = devnull.fileno()
+
+            child = client.ShellSession(LIST_FD_CMD)
+            time.sleep(SLEEP)
+            self.assertFalse(DEVNULL in child.get_output())
+            child.close()
+
+            child = client.ShellSession(LIST_FD_CMD, pass_fds=[fd])
+            time.sleep(SLEEP)
+            self.assertTrue(DEVNULL in child.get_output())
+            child.close()


### PR DESCRIPTION
aexpect.client: To support fd passing

Add new argument `pass_fds` for `Spawn`/`Tail`/`Expect`/`ShellSession`
and their related wrappers to support fd passing.

In python 2, the above utilities do support (implicit) fd passing, but
these would not work in python 3 for some reasons. By applying this
patch, now users can pass fds to the target process explicitly, and
implicit fd passing is not allowed.

Signed-off-by: Xu Han xuhan@redhat.com

----
Changes:
```
v2:  replace subprocess with subprocess32
```