### PR TITLE
To support fd passing [v3]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,4 +59,5 @@ if __name__ == '__main__':
           packages=['aexpect',
                     'aexpect.utils'],
           scripts=['scripts/aexpect-helper'],
-          use_2to3=True)
+          use_2to3=True,
+          install_requires=['subprocess32>=3.2.6;python_version<"3"'])

--- a/tests/test_pass_fds.py
+++ b/tests/test_pass_fds.py
@@ -1,0 +1,49 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2018
+# Author: Xu Han <xuhan@redhat.com>
+
+import os
+import unittest
+
+from aexpect import client
+
+
+LIST_FD_CMD = ('''python -c "import os; os.system('ls -l /proc/%d/fd' % '''
+               '''os.getpid())"''')
+
+
+class PassfdsTest(unittest.TestCase):
+
+    @unittest.skipUnless(os.path.exists('/proc/1/fd'), "requires Linux")
+    def test_pass_fds_spawn(self):
+        """
+        Tests fd passing for `client.Spawn`
+        """
+        with open(os.devnull, "r") as devnull:
+            fd = devnull.fileno()
+
+            child = client.Spawn(LIST_FD_CMD)
+            self.assertFalse(bool(child.get_status()),
+                             "child terminated abnormally")
+            self.assertFalse(os.devnull in child.get_output())
+            child.close()
+
+            child = client.Spawn(LIST_FD_CMD, pass_fds=[fd])
+            self.assertFalse(bool(child.get_status()),
+                             "child terminated abnormally")
+            self.assertTrue(os.devnull in child.get_output())
+            child.close()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
aexpect.client: To support fd passing

Add new argument `pass_fds` for `Spawn`/`Tail`/`Expect`/`ShellSession`
and their related wrappers to support fd passing.

In python 2, the above utilities do support (implicit) fd passing, but
these would not work in python 3 for some reasons. By applying this
patch, now users can pass fds to the target process explicitly, and
implicit fd passing is not allowed.

Signed-off-by: Xu Han xuhan@redhat.com

----
Changes:
```
v2:  replace subprocess with subprocess32
v3:  install denpendence via setup.py
```