### PR TITLE
spec: Add new requirements for python2

### DIFF
--- a/python-aexpect.spec
+++ b/python-aexpect.spec
@@ -47,6 +47,7 @@ Source0: https://github.com/avocado-framework/%{srcname}/archive/%{commit}.tar.g
 BuildArch: noarch
 Requires: python
 BuildRequires: python2-devel
+BuildRequires: python-subprocess32
 
 %if %{with_python3}
 Requires: python3
@@ -64,6 +65,7 @@ sftp, telnet, among others.
 
 %package -n python2-%{srcname}
 Summary: %{summary}
+Requires: python-subprocess32
 %{?python_provide:%python_provide python2-%{srcname}}
 
 %description -n python2-%{srcname}


### PR DESCRIPTION
This adds the new requirements to RPM spec file. We still need to decide
whether to ask for "python-subprocess32" in EPEL or to skip the new
requirement and create a custom (simplified) backport as described in:

    https://github.com/avocado-framework/aexpect/pull/32

but currently this builds well on Fedora.27

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>