### PR TITLE
setup: Avoid using unsupported "install_requires" expression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
 import os
+import sys
 # pylint: disable=E0611
 
 from setuptools import setup
@@ -50,6 +51,10 @@ def get_avocado_libexec_dir():
 
 
 if __name__ == '__main__':
+    if sys.version_info[0] == 2:
+        REQUIREMENTS = ['subprocess32>=3.2.6']
+    else:
+        REQUIREMENTS = []
     setup(name='aexpect',
           version='1.5.0',
           description='Aexpect',
@@ -60,4 +65,4 @@ if __name__ == '__main__':
                     'aexpect.utils'],
           scripts=['scripts/aexpect-helper'],
           use_2to3=True,
-          install_requires=['subprocess32>=3.2.6;python_version<"3"'])
+          install_requires=REQUIREMENTS)


### PR DESCRIPTION
The "install_requires" can (at least on my python 2.7.5 with pip 10.0.1)
only be simple requires without python version dependency. Let's address
this programatically.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>