### PR TITLE
Tests: add a basic client/Spawn test [v2]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - "2.6"
     - "2.7"
     - "3.4"
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-PYTHON=`which python`
+PYTHON=$(shell which python 2>/dev/null || which python3 2>/dev/null)
+PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | grep -q '\-\-user'); then echo "--user"; else echo ""; fi)
 DESTDIR=/
 BUILDIR=$(CURDIR)/debian/aexpect
 PROJECT=aexpect
@@ -71,8 +72,10 @@ rpm-release: srpm-release
 	if test ! -d BUILD/RPM; then mkdir -p BUILD/RPM; fi
 	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/python-aexpect-$(VERSION)-*.src.rpm
 
-check:
+check: clean
 	inspekt checkall
+	$(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS)
+	$(PYTHON) setup.py test
 
 clean:
 	$(PYTHON) setup.py clean

--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -181,8 +181,9 @@ class Spawn(object):
             # try to find python specific version of aexpect-helper first, then
             # try unversioned
             helper_noversion = 'aexpect-helper'
-            helper_versioned = '{0}-{1.major}.{1.minor}'.format(
-                helper_noversion, sys.version_info)
+            helper_versioned = '{0}-{1}.{2}'.format(helper_noversion,
+                                                    sys.version_info[0],
+                                                    sys.version_info[1])
             try:
                 helper_cmd = utils_path.find_command(helper_versioned)
             except utils_path.CmdNotFoundError:

--- a/setup.py
+++ b/setup.py
@@ -13,41 +13,10 @@
 # Copyright: Red Hat Inc. 2013-2015
 # Author: Lucas Meneghel Rodrigues <lmr@redhat.com>
 
-import os
 import sys
 # pylint: disable=E0611
 
 from setuptools import setup
-
-VIRTUAL_ENV = 'VIRTUAL_ENV' in os.environ
-
-
-def get_dir(system_path=None, virtual_path=None):
-    """
-    Retrieve VIRTUAL_ENV friendly path
-    :param system_path: Relative system path
-    :param virtual_path: Overrides system_path for virtual_env only
-    :return: VIRTUAL_ENV friendly path
-    """
-    if virtual_path is None:
-        virtual_path = system_path
-    if VIRTUAL_ENV:
-        if virtual_path is None:
-            virtual_path = []
-        return os.path.join(*virtual_path)
-    else:
-        if system_path is None:
-            system_path = []
-        return os.path.join(*(['/'] + system_path))
-
-
-def get_avocado_libexec_dir():
-    if VIRTUAL_ENV:
-        return get_dir(['libexec'])
-    elif os.path.exists('/usr/libexec'):    # RHEL-like distro
-        return get_dir(['usr', 'libexec', 'avocado'])
-    else:                                   # Debian-like distro
-        return get_dir(['usr', 'lib', 'avocado'])
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,5 @@ if __name__ == '__main__':
                     'aexpect.utils'],
           scripts=['scripts/aexpect-helper'],
           use_2to3=True,
-          install_requires=REQUIREMENTS)
+          install_requires=REQUIREMENTS,
+          test_suite='tests')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,37 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2018
+# Author: Cleber Rosa <crosa@redhat.com>
+
+import random
+import string
+import sys
+import unittest
+
+from aexpect import client
+
+
+class ClientTest(unittest.TestCase):
+
+    def test_client_spawn(self):
+        """
+        Tests the basic spawning of an interactive process
+        """
+        key = "".join([random.choice(string.ascii_uppercase)
+                       for _ in range(10)])
+        python = client.Spawn(sys.executable)
+        self.assertTrue(python.is_alive())
+        python.sendline("print('%s')" % key)
+        python.sendline("quit()")
+        self.assertEqual(python.get_status(), 0)
+        self.assertIn(key, python.get_output())
+        self.assertFalse(python.is_alive())


### PR DESCRIPTION
And the very minimum test infrastructure.  This should allow one
to run the tests by doing the classical:

 $ python setup.py test

And of course can and will be extended/enabled on `make check`,
Travis-CI, etc.

---

Changes from v1 (#28):
 * The test itself was completely rewritten (and simplified)