### PR TITLE
client: Fix the issue of getting command status

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -1237,7 +1237,7 @@ class ShellSession(Expect):
         out = self.cmd_output(cmd, timeout, internal_timeout, print_func, safe)
         try:
             # Send the 'echo $?' (or equivalent) command to get the exit status
-            status = self.cmd_output(self.status_test_command, 10,
+            status = self.cmd_output(self.status_test_command, 30,
                                      internal_timeout, print_func, safe)
         except ShellError:
             raise ShellStatusError(cmd, out)


### PR DESCRIPTION
When a system is under heavy load, calling `s.cmd_status_output()`
might get `ShellStatusError`, the problem is the command of
getting status may not finish in 10s (the current value).

The patch tries to solve the problem by enlarging the value to 30s.

Signed-off-by: Xu Han <xuhan@redhat.com>