### PR TITLE
Update inspektor in travis to 0.5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ rpm-release: srpm-release
 	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/python-aexpect-$(VERSION)-*.src.rpm
 
 check: clean
-	inspekt checkall --disable-lint W1618
+	inspekt checkall --disable-lint W1618,R0205
 	$(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS)
 	$(PYTHON) setup.py test
 

--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -423,7 +423,7 @@ class Spawn(object):
         """
         char = char.lower()
         val = ord(char)
-        if val >= 97 and val <= 122:
+        if 97 <= val <= 122:
             val = val - 97 + 1  # ctrl+a = '\0x01'
             return self.send(chr(val))
         mapping = {'@': 0, '`': 0,
@@ -1247,8 +1247,7 @@ class ShellSession(Expect):
                        if self.__RE_STATUS.match(l.strip())]
         if digit_lines:
             return int(digit_lines[0].strip()), out
-        else:
-            raise ShellStatusError(cmd, out)
+        raise ShellStatusError(cmd, out)
 
     def cmd_status(self, cmd, timeout=60, internal_timeout=None,
                    print_func=None, safe=False):

--- a/aexpect/utils/path.py
+++ b/aexpect/utils/path.py
@@ -60,8 +60,7 @@ def find_command(cmd, default=None):
 
     if default is not None:
         return default
-    else:
-        raise CmdNotFoundError(cmd, path_paths)
+    raise CmdNotFoundError(cmd, path_paths)
 
 
 def init_dir(*args):

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,2 +1,2 @@
 pycodestyle==2.4.0
-inspektor==0.4.5
+inspektor==0.5.2


### PR DESCRIPTION
The latest pylint version being installed by travis (2.0.1) is breaking due to:

https://github.com/PyCQA/pylint/issues/1318

Inspektor 0.5.2 has a pylint 2.0 compatibility commit:

https://github.com/avocado-framework/inspektor/commit/d72a157a0d59b42f456c46d07d8b21f7e0cab274

This PR updates the lint requirements to inspektor==0.5.2 and fixes issues reported by the new pylint version.