### PR TITLE
Add missing match '[1S' for output

### DIFF
--- a/aexpect/utils/astring.py
+++ b/aexpect/utils/astring.py
@@ -36,7 +36,7 @@ def strip_console_codes(output, custom_codes=None):
     index = 0
     output = "\x1b[m%s" % output
     console_codes = "%[G@8]|\\[[@A-HJ-MPXa-hl-nqrsu\\`]"
-    console_codes += "|\\[[\\d;]+[HJKgqnrm]|#8|\\([B0UK]|\\)"
+    console_codes += "|\\[[\\d;]+[HJKSgqnrm\\d]?|#8|\\([B0UK]|\\)|O[P-S]"
     if custom_codes is not None and custom_codes not in console_codes:
         console_codes += "|%s" % custom_codes
     while index < len(output):


### PR DESCRIPTION
May get output like '[1S' which need to match

Signed-off-by: Kylazhang <weizhan@redhat.com>