### PR TITLE
Allow binary fragments in the output

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -331,8 +331,10 @@ class Spawn(object):
         Return the STDOUT and STDERR output of the process so far.
         """
         try:
-            with open(self.output_filename, 'r') as output_file:
-                return output_file.read()
+            with open(self.output_filename, 'rb') as output_file:
+                errors = ('replace' if sys.version_info[0] < 3 else
+                          'backslashreplace')
+                return output_file.read().decode(self.encoding, errors)
         except IOError:
             return None
 


### PR DESCRIPTION
Sometimes the output might contain binary fragments, that are not
parsable to the system encoding. Let's use 'replace', resp
'backslashreplace' in get_output to allow such segments without
erroring-out. This should be fairly consistent as we do 'ignore'
most of the time.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>