### PR TITLE
Fix fallout from exception catch refactoring in fdff994efd

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -1204,8 +1204,7 @@ class ShellSession(Expect):
                 success = True
                 break
             except ExpectTimeoutError as error:
-                output = self.remove_command_echo(error.output, cmd)
-                raise ShellTimeoutError(cmd, output)
+                self.sendline()
             except ExpectProcessTerminatedError as error:
                 output = self.remove_command_echo(error.output, cmd)
                 raise ShellProcessTerminatedError(cmd, error.status, output)


### PR DESCRIPTION
The safer cmd_output call disregards ExpectTimeoutError exceptions
and sends an extra new line to clear the shell prompt in case of
unwanted ouput which made it fail previously matching the same prompt.

Signed-off-by: Plamen Dimitrov <pdimitrov@pevogam.com>