### PR TITLE
Remove vestigial python shebang line from rss_client.py

### DIFF
--- a/aexpect/rss_client.py
+++ b/aexpect/rss_client.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or


### PR DESCRIPTION
The file `aexpect/rss_client.py` contains an unnecessary `#!/usr/bin/python` line that, when packaged, results in the following error when `rpmlint` is run:

```
python3-aexpect.noarch: E: non-executable-script /usr/lib/python3.9/site-packages/aexpect/rss_client.py 644 /usr/bin/python 
```

This PR simply removes that extraneous line to clean up the error.
