### PR TITLE
Not stop reading output when there's no new output from any attempt

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -855,7 +855,7 @@ class Expect(Tail):
             data = self.read_nonblocking(internal_timeout,
                                          end_time - time.time())
             if not data:
-                break
+                continue
             # Print it if necessary
             if print_func:
                 for line in data.splitlines():


### PR DESCRIPTION
Sometimes output could be printed out a little slow and there could
be no new output from an attempt. But that doesn't mean there's not
going to be new output just seconds later. If we break the loop
every time there's no new output, we could end up with raising
`ExpectError: Unknown error occurred`. This commit should fix the
issue.

Signed-off-by: Haijiao Zhao <haizhao@redhat.com>