### PR TITLE
Make sure read_until_output_matches waits for all data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 language: python
 
 python:
-    - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"

--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -866,10 +866,12 @@ class Expect(Tail):
             if not poll_status:
                 raise ExpectTimeoutError(patterns, output)
             # Read data from child
-            data = self.read_nonblocking(internal_timeout,
-                                         end_time - time.time())
-            if not data:
+            read, data = self._read_nonblocking(internal_timeout,
+                                                end_time - time.time())
+            if not read:
                 break
+            if not data:
+                continue
             # Print it if necessary
             if print_func:
                 for line in data.splitlines():

--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -733,7 +733,7 @@ class Expect(Tail):
     def __getinitargs__(self):
         return Tail.__getinitargs__(self)
 
-    def read_nonblocking(self, internal_timeout=None, timeout=None):
+    def _read_nonblocking(self, internal_timeout=None, timeout=None):
         """
         Read from child until there is nothing to read for timeout seconds.
 
@@ -741,6 +741,7 @@ class Expect(Tail):
                                  reading from the child process, or None to
                                  use the default value.
         :param timeout: Timeout for reading child process output.
+        :returns: tuple(number_of_read_raw_chars, decoded_string)
         """
         if internal_timeout is None:
             internal_timeout = 100
@@ -753,21 +754,34 @@ class Expect(Tail):
         poller = select.poll()
         poller.register(expect_pipe, select.POLLIN)
         data = ""
+        read = 0
         while True:
             try:
                 poll_status = poller.poll(internal_timeout)
             except select.error:
-                return data
+                return read, data
             if poll_status:
-                new_data = os.read(expect_pipe, 1024).decode(self.encoding,
-                                                             "ignore")
-                if not new_data:
-                    return data
-                data += new_data
+                raw_data = os.read(expect_pipe, 1024)
+                if not raw_data:
+                    return read, data
+                read += len(raw_data)
+                data += raw_data.decode(self.encoding, "ignore")
             else:
-                return data
+                return read, data
             if end_time and time.time() > end_time:
-                return data
+                return read, data
+
+    def read_nonblocking(self, internal_timeout=None, timeout=None):
+        """
+        Read from child until there is nothing to read for timeout seconds.
+
+        :param internal_timeout: Time (seconds) to wait before we give up
+                                 reading from the child process, or None to
+                                 use the default value.
+        :param timeout: Timeout for reading child process output.
+        :returns: decoded string
+        """
+        return self._read_nonblocking(internal_timeout, timeout)[1]
 
     @staticmethod
     def match_patterns(cont, patterns):

--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -179,7 +179,7 @@ class Spawn(object):
         # Start the server (which runs the command)
         if command:
             helper_cmd = utils_path.find_command('aexpect_helper')
-            self._aexpect_helper = subprocess.Popen([helper_cmd],
+            self._aexpect_helper = subprocess.Popen([helper_cmd],   # pylint: disable=R1732,E0012
                                                     shell=True,
                                                     stdin=subprocess.PIPE,
                                                     stdout=subprocess.PIPE,

--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -179,7 +179,7 @@ class Spawn(object):
         # Start the server (which runs the command)
         if command:
             helper_cmd = utils_path.find_command('aexpect_helper')
-            self._aexpect_helper = subprocess.Popen([helper_cmd],   # pylint: disable=R1732,E0012
+            self._aexpect_helper = subprocess.Popen([helper_cmd],   # pylint: disable=R1732
                                                     shell=True,
                                                     stdin=subprocess.PIPE,
                                                     stdout=subprocess.PIPE,

--- a/aexpect/utils/process.py
+++ b/aexpect/utils/process.py
@@ -18,9 +18,9 @@ import os
 
 def getoutput(cmd):
     """Executes command and returns stdout+stderr without tailing \n\r"""
-    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-    return proc.communicate()[0].decode().rstrip("\n\r")
+    with subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE) as proc:
+        return proc.communicate()[0].decode().rstrip("\n\r")
 
 
 class CmdError(Exception):

--- a/scripts/aexpect_helper
+++ b/scripts/aexpect_helper
@@ -86,9 +86,8 @@ def main():     # too-many-* pylint:disable=R0914,R0912,R0915
                                                                   command)
             tmp_file = tempfile.mktemp(suffix='.sh',
                                        prefix='aexpect-', dir=base_dir)
-            fd_cmd = open(tmp_file, "w")
-            fd_cmd.write(command)
-            fd_cmd.close()
+            with open(tmp_file, "w") as fd_cmd:
+                fd_cmd.write(command)
             os.execv("/bin/bash", ["/bin/bash", "-c", "source %s" % tmp_file])
             os.remove(tmp_file)
         else:
@@ -103,92 +102,92 @@ def main():     # too-many-* pylint:disable=R0914,R0912,R0915
         makestandard(shell_fd, echo)
 
         server_log.info('Opening output file %s', output_filename)
-        output_file = open(output_filename, "wb")
-        server_log.info('Opening input pipe %s', inpipe_filename)
-        os.mkfifo(inpipe_filename)
-        inpipe_fd = os.open(inpipe_filename, os.O_RDWR)
-        server_log.info('Opening control pipe %s', ctrlpipe_filename)
-        os.mkfifo(ctrlpipe_filename)
-        ctrlpipe_fd = os.open(ctrlpipe_filename, os.O_RDWR)
-        # Open output pipes (readers)
-        reader_fds = []
-        for filename in reader_filenames:
-            server_log.info('Opening output pipe %s', filename)
-            os.mkfifo(filename)
-            reader_fds.append(os.open(filename, os.O_RDWR))
-        server_log.info('Reader fd list: %s', reader_fds)
+        with open(output_filename, "wb") as output_file:
+            server_log.info('Opening input pipe %s', inpipe_filename)
+            os.mkfifo(inpipe_filename)
+            inpipe_fd = os.open(inpipe_filename, os.O_RDWR)
+            server_log.info('Opening control pipe %s', ctrlpipe_filename)
+            os.mkfifo(ctrlpipe_filename)
+            ctrlpipe_fd = os.open(ctrlpipe_filename, os.O_RDWR)
+            # Open output pipes (readers)
+            reader_fds = []
+            for filename in reader_filenames:
+                server_log.info('Opening output pipe %s', filename)
+                os.mkfifo(filename)
+                reader_fds.append(os.open(filename, os.O_RDWR))
+            server_log.info('Reader fd list: %s', reader_fds)
 
-        # Write shell PID to file
-        server_log.info('Writing shell PID file %s', shell_pid_filename)
-        with open(shell_pid_filename, "w") as file_obj:
-            file_obj.write(str(shell_pid))
+            # Write shell PID to file
+            server_log.info('Writing shell PID file %s', shell_pid_filename)
+            with open(shell_pid_filename, "w") as file_obj:
+                file_obj.write(str(shell_pid))
 
-        # Print something to stdout so the client can start working
-        print("Server %s ready" % a_id)    # py3k pylint: disable=C0325
-        sys.stdout.flush()
+            # Print something to stdout so the client can start working
+            print("Server %s ready" % a_id)    # py3k pylint: disable=C0325
+            sys.stdout.flush()
 
-        # Initialize buffers
-        buffers = [b"" for reader in readers]
+            # Initialize buffers
+            buffers = [b"" for reader in readers]
 
-        # Read from child and write to files/pipes
-        server_log.info('Entering main read loop')
-        status = 1  # lgtm [py/multiple-definition]
-        while True:
-            check_termination = False
-            # Make a list of reader pipes whose buffers are not empty
-            fds = [reader_fd for (i, reader_fd) in enumerate(reader_fds)
-                   if buffers[i]]
-            # Wait until there's something to do
-            r_fds, w_fds = select.select([shell_fd, inpipe_fd, ctrlpipe_fd],
-                                         fds, [], 0.5)[:2]
-            # If a reader pipe is ready for writing --
-            for (i, reader_fd) in enumerate(reader_fds):
-                if reader_fd in w_fds:
-                    bytes_written = os.write(reader_fd, buffers[i])
-                    buffers[i] = buffers[i][bytes_written:]
-            if ctrlpipe_fd in r_fds:
-                cmd_len = int(os.read(ctrlpipe_fd, 10))
-                data = os.read(ctrlpipe_fd, cmd_len)
-                if data == "raw":
-                    makeraw(shell_fd)
-                elif data == "standard":
-                    makestandard(shell_fd, echo)
-            # If there's data to read from the child process --
-            if shell_fd in r_fds:
-                try:
-                    data = os.read(shell_fd, 16384)
-                except OSError:
-                    data = b""
-                if not data:
-                    check_termination = True
-                # Remove carriage returns from the data -- they often cause
-                # trouble and are normally not needed
-                data = data.replace(b"\r", b"")
-                output_file.write(data)
-                output_file.flush()
-                for i in range(len(readers)):
-                    buffers[i] += data
-            # If os.read() raised an exception or there was nothing to read --
-            if check_termination or shell_fd not in r_fds:
-                pid, status = os.waitpid(shell_pid, os.WNOHANG)
-                if pid:
-                    status = os.WEXITSTATUS(status)
-                    break
-            # If there's data to read from the client --
-            if inpipe_fd in r_fds:
-                data = os.read(inpipe_fd, 1024)
-                os.write(shell_fd, data)
+            # Read from child and write to files/pipes
+            server_log.info('Entering main read loop')
+            status = 1  # lgtm [py/multiple-definition]
+            while True:
+                check_termination = False
+                # Make a list of reader pipes whose buffers are not empty
+                fds = [reader_fd for (i, reader_fd) in enumerate(reader_fds)
+                       if buffers[i]]
+                # Wait until there's something to do
+                r_fds, w_fds = select.select([shell_fd, inpipe_fd,
+                                              ctrlpipe_fd],
+                                             fds, [], 0.5)[:2]
+                # If a reader pipe is ready for writing --
+                for (i, reader_fd) in enumerate(reader_fds):
+                    if reader_fd in w_fds:
+                        bytes_written = os.write(reader_fd, buffers[i])
+                        buffers[i] = buffers[i][bytes_written:]
+                if ctrlpipe_fd in r_fds:
+                    cmd_len = int(os.read(ctrlpipe_fd, 10))
+                    data = os.read(ctrlpipe_fd, cmd_len)
+                    if data == "raw":
+                        makeraw(shell_fd)
+                    elif data == "standard":
+                        makestandard(shell_fd, echo)
+                # If there's data to read from the child process --
+                if shell_fd in r_fds:
+                    try:
+                        data = os.read(shell_fd, 16384)
+                    except OSError:
+                        data = b""
+                    if not data:
+                        check_termination = True
+                    # Remove carriage returns from the data; they often cause
+                    # trouble and are normally not needed
+                    data = data.replace(b"\r", b"")
+                    output_file.write(data)
+                    output_file.flush()
+                    for i in range(len(readers)):
+                        buffers[i] += data
+                # os.read() raised an exception or there was nothing to read
+                if check_termination or shell_fd not in r_fds:
+                    pid, status = os.waitpid(shell_pid, os.WNOHANG)
+                    if pid:
+                        status = os.WEXITSTATUS(status)
+                        break
+                # If there's data to read from the client --
+                if inpipe_fd in r_fds:
+                    data = os.read(inpipe_fd, 1024)
+                    os.write(shell_fd, data)
 
-        server_log.info('Out of the main read loop. Writing status to %s',
-                        status_filename)
-        with open(status_filename, "w") as file_obj:
-            file_obj.write(str(status))
+            server_log.info('Out of the main read loop. Writing status to %s',
+                            status_filename)
+            with open(status_filename, "w") as file_obj:
+                file_obj.write(str(status))
 
-        # Wait for the client to finish initializing
-        wait_for_lock(lock_client_starting_filename)
+            # Wait for the client to finish initializing
+            wait_for_lock(lock_client_starting_filename)
 
         # Close all files and pipes
-        output_file.close()
         os.close(inpipe_fd)
         server_log.info('Closed input pipe')
         for reader_fd in reader_fds:


### PR DESCRIPTION
In case the output produces non-decodable characters the `read_until_output_matches` can return earlier as it considers that a closed pipeline. Let's detect the closed pipeline by counting the raw bytes rather than decoded value with ignored values.

This is an alternative solution of the issue described in: https://github.com/avocado-framework/aexpect/pull/78