### PR TITLE
Add six dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,5 @@ if __name__ == '__main__':
           packages=['aexpect',
                     'aexpect.utils'],
           scripts=['scripts/aexpect_helper'],
-          test_suite='tests')
+          test_suite='tests',
+          install_requires=['six'])


### PR DESCRIPTION
Aexpect requires six, let's include it in our setup.py.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>