### PR TITLE
Include previous output in cmd_output_safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ COMMIT_DATE=$(shell git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
 MOCK_CONFIG=default
 
 all:
-	@echo "make check - Runs tree static check, unittests and functional tests"
+	@echo "make check - Runs tree static check, unittests and functional tests. Some tests are only executed when AEXPECT_TIME_SENSITIVE=yes is set."
 	@echo "make clean - Get rid of scratch and byte files"
 	@echo "make source - Create source package"
 	@echo "make install - Install on local system"

--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -1217,13 +1217,15 @@ class ShellSession(Expect):
                 out += self.read_up_to_prompt(0.5)
                 success = True
                 break
-            except ExpectTimeoutError:
+            except ExpectTimeoutError as error:
+                out = f"{out}{error.output}"
                 self.sendline()
             except ExpectProcessTerminatedError as error:
-                output = self.remove_command_echo(error.output, cmd)
-                raise ShellProcessTerminatedError(cmd, error.status, output) from error
+                output = self.remove_command_echo(f"{out}{error.output}", cmd)
+                raise ShellProcessTerminatedError(cmd, error.status,
+                                                  output) from error
             except ExpectError as error:
-                output = self.remove_command_echo(error.output, cmd)
+                output = self.remove_command_echo(f"{out}{error.output}", cmd)
                 raise ShellError(cmd, output) from error
 
         if not success:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,6 +14,7 @@
 
 # selftests pylint: disable=C0111,C0111
 
+import os
 import random
 import string
 import sys
@@ -111,6 +112,21 @@ class CommandsTests(unittest.TestCase):
                         self.fail(f"Incorrect exception '{details}' "
                                   f"({type(details)}) was raised "
                                   f"using command {cmd} ({self.cmds})")
+
+    @unittest.skipUnless(os.environ.get('AEXPECT_TIME_SENSITIVE'),
+                         "AEXPECT_TIME_SENSITIVE env variable not set")
+    def test_cmd_output_with_inner_timeout(self):
+        """
+        cmd_output_safe uses 0.5s inner timeout, make sure all lines are
+        present in the output.
+        """
+        session = client.ShellSession("sh")
+        out = session.cmd_output_safe("echo FIRST LINE; sleep 2; "
+                                      "echo SECOND LINE; sleep 2; "
+                                      "echo THIRD LINE")
+        self.assertIn("FIRST LINE", out)
+        self.assertIn("SECOND LINE", out)
+        self.assertIn("THIRD LINE", out)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The ShellSession.cmd_output_safe uses 0.5 inner timeout to get the
output which is not stored for following iterations. Similarly the
exceptions only use the current iteration output, leaving the previous
iteration(s) output discarded.

As this test is time-sensitive (or long) this commit introduces a
conditional selftest which is only executed when AEXPECT_TIME_SENSITIVE
is set. This should be performed at least before a release.

Reported-by: Yumei Huang yuhuang@redhat.com
Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>

Fixes: #84 