### PR TITLE
Add logging namespace for all relevant aexpect modules

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -54,6 +54,8 @@ from aexpect.utils import wait as utils_wait
 
 _THREAD_KILL_REQUESTED = threading.Event()
 
+LOG = logging.getLogger(__name__)
+
 
 def kill_tail_threads():
     """
@@ -1168,7 +1170,7 @@ class ShellSession(Expect):
         """
         if safe:
             return self.cmd_output_safe(cmd, timeout)
-        logging.debug("Sending command: %s", cmd)
+        LOG.debug("Sending command: %s", cmd)
         self.read_nonblocking(0, timeout)
         self.sendline(cmd)
         try:
@@ -1206,7 +1208,7 @@ class ShellSession(Expect):
                 terminates while waiting for output
         :raise ShellError: Raised if an unknown error occurs
         """
-        logging.debug("Sending command (safe): %s", cmd)
+        LOG.debug("Sending command (safe): %s", cmd)
         self.read_nonblocking(0, timeout)
         self.sendline(cmd)
         out = ""

--- a/aexpect/utils/wait.py
+++ b/aexpect/utils/wait.py
@@ -13,6 +13,7 @@
 
 import time
 import logging
+
 _LOG = logging.getLogger(__file__)
 
 


### PR DESCRIPTION
As Aexpect is a library used by other applications, it makes sense
to limits its logging and not log directly to the root logger.

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>