### PR TITLE
CI: bump pylint to version known to work with released inspektor

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,2 +1,4 @@
+astroid==1.2.1
+pylint==1.3.1
 pycodestyle==2.4.0
 inspektor==0.5.2


### PR DESCRIPTION
CI is failing due to incompatibility of latest inspektor and latest
pylint.  Let's pin pylint version to a known working version.

Signed-off-by: Cleber Rosa <crosa@redhat.com>