### PR TITLE
CI: bump Travis requirements for inspektor

### DIFF
--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,2 +1,2 @@
 pycodestyle==2.4.0
-inspektor==0.5.2
+inspektor==0.5.3


### PR DESCRIPTION
Newly release inspektor adds compatiblity with latest pylint versions
and fixes the current CI failure.

Signed-off-by: Cleber Rosa <crosa@redhat.com>