### PR TITLE
astring: Add bracketed paste console codes

### DIFF
--- a/aexpect/utils/astring.py
+++ b/aexpect/utils/astring.py
@@ -36,7 +36,7 @@ def strip_console_codes(output, custom_codes=None):
     index = 0
     output = f"\x1b[m{output}"
     console_codes = "%[G@8]|\\[[@A-HJ-MPXa-hl-nqrsu\\`]"
-    console_codes += "|\\[[\\d;]+[HJKgqnrm]|#8|\\([B0UK]|\\)"
+    console_codes += "|\\[[\\d;]+[HJKgqnrm]|#8|\\([B0UK]|\\)|\\[\\?2004[lh]"
     if custom_codes is not None and custom_codes not in console_codes:
         console_codes += f"|{custom_codes}"
     while index < len(output):


### PR DESCRIPTION
the bracketed-paste generates '\x1b[?2004l' and '\x1b[?2004h' console
codes that needs to be added to the list of console codes otherwise such
output breaks 'strip_console_codes'.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>