### PR TITLE
Simpler ns daemon and current linter fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ rpm-release: srpm-release
 	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/python-aexpect-$(VERSION)-*.src.rpm
 
 check: clean
-	inspekt checkall --disable-lint W1618,R0205
+	inspekt checkall --disable-lint R0205
 	$(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS)
 	$(PYTHON) setup.py test
 


### PR DESCRIPTION
The previous approach of using a variable initialied only on given
condition after verifying the same condition seems to be all too
convoluted for linters so let's simplify it until they are happy.

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>