### PR TITLE
Provide the session prefix when logging sent commands

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -1185,7 +1185,8 @@ class ShellSession(Expect):
         """
         if safe:
             return self.cmd_output_safe(cmd, timeout)
-        LOG.debug("Sending command: %s", cmd)
+        session_tag = f"[{self.output_prefix}] " if self.output_prefix else ""
+        LOG.debug("%sSending command: %s", session_tag, cmd)
         self.read_nonblocking(0, timeout)
         self.sendline(cmd)
         try:
@@ -1223,7 +1224,8 @@ class ShellSession(Expect):
                 terminates while waiting for output
         :raise ShellError: Raised if an unknown error occurs
         """
-        LOG.debug("Sending command (safe): %s", cmd)
+        session_tag = f"[{self.output_prefix}] " if self.output_prefix else ""
+        LOG.debug("%sSending command (safe): %s", session_tag, cmd)
         self.read_nonblocking(0, timeout)
         self.sendline(cmd)
         out = ""

--- a/aexpect/remote.py
+++ b/aexpect/remote.py
@@ -414,8 +414,8 @@ def remote_login(client, host, port, username, password, prompt, linesep="\n",
 
     if verbose:
         LOG.debug("Login command: '%s'", cmd)
-    session = RemoteSession(cmd, linesep=linesep, prompt=prompt,
-                            status_test_command=status_test_command,
+    session = RemoteSession(cmd, linesep=linesep, output_prefix=host,
+                            prompt=prompt, status_test_command=status_test_command,
                             client=client, host=host, port=port,
                             username=username, password=password)
     try:


### PR DESCRIPTION
In cases where one works with multiple (and many) remote hosts and sessions at the same time it is really useful to be able to see what remote host the command executed on.

Signed-off-by: Plamen Dimitrov <plamen.dimitrov@intra2net.com>