### PR TITLE
Avoid printing line when output_func not set

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -675,10 +675,11 @@ class Tail(Spawn):
                 else:
                     # No output is available right now; flush the bfr
                     if bfr:
-                        _print_line(bfr)
+                        if self.output_func:
+                            _print_line(bfr)
                         bfr = ""
             # The process terminated; print any remaining output
-            if bfr:
+            if bfr and self.output_func:
                 _print_line(bfr)
             # Get the exit status, print it and send it to termination_func
             status = self.get_status()


### PR DESCRIPTION
On two places we used to call _print_line even though self.output_func was not set, which resulted in warnings. It would be nicer to put this check directly to the _print_line function, but it is used inside performance critical section so let's check that directly on the corresponding places.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>