### PR TITLE
.github/workflows/ci.yml: Fix CI on python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.x]
+        python-version: [3.x]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
We are having an issue with running the CI on py3.6 because the reference 3.6 cannot be found on the
github python versions manifest [1]. Let's stick to 3.x only.

[1] https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json