### PR TITLE
python-aexpect.spec: Update spec with latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON_DEVELOP_ARGS=$(shell if ($(PYTHON) setup.py develop --help 2>/dev/null | 
 DESTDIR=/
 BUILDIR=$(CURDIR)/debian/aexpect
 PROJECT=aexpect
-VERSION="1.6.4"
+VERSION="1.7.0"
 COMMIT=$(shell git log --pretty=format:'%H' -n 1)
 SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1)
 COMMIT_DATE=$(shell git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)

--- a/python-aexpect.spec
+++ b/python-aexpect.spec
@@ -22,7 +22,7 @@
 %global with_tests 0
 
 Name: python-aexpect
-Version: 1.6.4
+Version: 1.7.0
 Release: 1%{?gitrel}%{?dist}
 Summary: Aexpect is a python library to control interactive applications
 
@@ -80,6 +80,9 @@ selftests/checkall
 %{_bindir}/aexpect_helper*
 
 %changelog
+* Tue Feb 28 2022 Lucas Meneghel Rodrigues <lmr@amazon.com> - 1.7.0-1
+- New release
+
 * Wed Dec  8 2021 Cleber Rosa <crosa@redhat.com> - 1.6.4-1
 - New release
 


### PR DESCRIPTION
I forgot to make that update when cutting 1.7.0.