### PR TITLE
Add static check with "avocado-static-checks"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install -r requirements-travis.txt
       - run: make check
+
+  static-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: run static checks
+        uses: avocado-framework/avocado-ci-tools@main
+        with:
+          avocado-static-checks: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "avocado-static-checks"]
+	path = static-checks
+	url = ../avocado-static-checks
+	branch = main

--- a/aexpect/__init__.py
+++ b/aexpect/__init__.py
@@ -14,23 +14,24 @@ Aexpect module, see help('aexpect.client') to get info about the main
 entry-points.
 """
 
-from .exceptions import ExpectError
-from .exceptions import ExpectProcessTerminatedError
-from .exceptions import ExpectTimeoutError
-from .exceptions import ShellCmdError
-from .exceptions import ShellError
-from .exceptions import ShellProcessTerminatedError
-from .exceptions import ShellStatusError
-from .exceptions import ShellTimeoutError
-
-from .client import Spawn
-from .client import Tail
-from .client import Expect
-from .client import ShellSession
-from .client import kill_tail_threads
-from .client import run_tail
-from .client import run_bg
-from .client import run_fg
-
-from . import remote
-from . import rss_client
+from . import remote, rss_client
+from .client import (
+    Expect,
+    ShellSession,
+    Spawn,
+    Tail,
+    kill_tail_threads,
+    run_bg,
+    run_fg,
+    run_tail,
+)
+from .exceptions import (
+    ExpectError,
+    ExpectProcessTerminatedError,
+    ExpectTimeoutError,
+    ShellCmdError,
+    ShellError,
+    ShellProcessTerminatedError,
+    ShellStatusError,
+    ShellTimeoutError,
+)

--- a/aexpect/exceptions.py
+++ b/aexpect/exceptions.py
@@ -27,8 +27,10 @@ class ExpectError(Exception):
         return f"patterns {self.patterns!r}"
 
     def __str__(self):
-        return ("Unknown error occurred while looking for "
-                f"{self._pattern_str()}    (output: {self.output!r})")
+        return (
+            "Unknown error occurred while looking for "
+            f"{self._pattern_str()}    (output: {self.output!r})"
+        )
 
 
 class ExpectTimeoutError(ExpectError):
@@ -36,8 +38,10 @@ class ExpectTimeoutError(ExpectError):
     """Timeout when looking for output"""
 
     def __str__(self):
-        return ("Timeout expired while looking for "
-                f"{self._pattern_str()}    (output: {self.output!r})")
+        return (
+            "Timeout expired while looking for "
+            f"{self._pattern_str()}    (output: {self.output!r})"
+        )
 
 
 class ExpectProcessTerminatedError(ExpectError):
@@ -49,9 +53,11 @@ class ExpectProcessTerminatedError(ExpectError):
         self.status = status
 
     def __str__(self):
-        return ("Process terminated while looking for "
-                f"{self._pattern_str()}    (status: {self.status!r},    "
-                f"output: {self.output!r})")
+        return (
+            "Process terminated while looking for "
+            f"{self._pattern_str()}    (status: {self.status!r},    "
+            f"output: {self.output!r})"
+        )
 
 
 class ShellError(Exception):
@@ -64,8 +70,10 @@ class ShellError(Exception):
         self.output = output
 
     def __str__(self):
-        return (f"Could not execute shell command {self.cmd!r}    "
-                "(output: {self.output!r})")
+        return (
+            f"Could not execute shell command {self.cmd!r}    "
+            "(output: {self.output!r})"
+        )
 
 
 class ShellTimeoutError(ShellError):
@@ -73,8 +81,10 @@ class ShellTimeoutError(ShellError):
     """Timeout when waiting for command to complete"""
 
     def __str__(self):
-        return ("Timeout expired while waiting for shell command to "
-                f"complete: {self.cmd!r}    (output: {self.output!r})")
+        return (
+            "Timeout expired while waiting for shell command to "
+            f"complete: {self.cmd!r}    (output: {self.output!r})"
+        )
 
 
 class ShellProcessTerminatedError(ShellError):
@@ -89,9 +99,11 @@ class ShellProcessTerminatedError(ShellError):
         self.status = status
 
     def __str__(self):
-        return ("Shell process terminated while waiting for command to "
-                f"complete: {self.cmd!r}    (status: {self.status},    "
-                f"output: {self.output!r})")
+        return (
+            "Shell process terminated while waiting for command to "
+            f"complete: {self.cmd!r}    (status: {self.status},    "
+            f"output: {self.output!r})"
+        )
 
 
 class ShellCmdError(ShellError):
@@ -106,8 +118,10 @@ class ShellCmdError(ShellError):
         self.status = status
 
     def __str__(self):
-        return (f"Shell command failed: {self.cmd!r}    (status: {self.status}"
-                f",    output: {self.output!r})")
+        return (
+            f"Shell command failed: {self.cmd!r}    (status: {self.status}"
+            f",    output: {self.output!r})"
+        )
 
 
 class ShellStatusError(ShellError):
@@ -117,5 +131,7 @@ class ShellStatusError(ShellError):
     """
 
     def __str__(self):
-        return (f"Could not get exit status of command: {self.cmd!r}    "
-                f"(output: {self.output!r})")
+        return (
+            f"Could not get exit status of command: {self.cmd!r}    "
+            f"(output: {self.output!r})"
+        )

--- a/aexpect/ops_linux.py
+++ b/aexpect/ops_linux.py
@@ -54,6 +54,7 @@ import logging
 from shlex import quote
 
 from aexpect.exceptions import ShellCmdError
+
 # Need this import for sphinx and other documentation to produce links later on
 # from .client import ShellSession
 
@@ -231,7 +232,7 @@ def ls(session, path, quote_path=True, flags="-1UNq"):  # pylint: disable=C0103
     Just like :py:func:`os.listdir`, does not include file names starting with
     dot (`'.'`)
     """
-    cmd = f'ls {flags} {quote(path)}' if quote_path else f'ls {flags} {path}'
+    cmd = f"ls {flags} {quote(path)}" if quote_path else f"ls {flags} {path}"
     status, output = session.cmd_status_output(cmd)
     status, output = _process_status_output(cmd, status, output)
     return output.splitlines()
@@ -253,7 +254,7 @@ def glob(session, glob_pattern):
     Alternative implementations are either shell specific or use `echo` and
     thus cannot handle spaces in paths well.
     """
-    cmd = f'find {glob_pattern} -maxdepth 0'
+    cmd = f"find {glob_pattern} -maxdepth 0"
     status, output = session.cmd_status_output(cmd)
     if status == 1:
         return []
@@ -276,8 +277,11 @@ def move(session, source, target, quote_path=True, flags=""):
     Calls `mv source target` through a session. See `man mv` for what source
     and target can be and what behavior to expect.
     """
-    cmd = f'mv {flags} {quote(source)} {quote(target)}' if quote_path \
-        else f'mv {flags} {source} {target}'
+    cmd = (
+        f"mv {flags} {quote(source)} {quote(target)}"
+        if quote_path
+        else f"mv {flags} {source} {target}"
+    )
     status, output = session.cmd_status_output(cmd)
     _process_status_output(cmd, status, output)
 
@@ -297,8 +301,11 @@ def copy(session, source, target, quote_path=True, flags=""):
     Calls `cp source target` through a session. See `man cp` for what source
     and target can be and what behavior to expect.
     """
-    cmd = f'cp {flags} {quote(source)} {quote(target)}' if quote_path \
-        else f'cp {flags} {source} {target}'
+    cmd = (
+        f"cp {flags} {quote(source)} {quote(target)}"
+        if quote_path
+        else f"cp {flags} {source} {target}"
+    )
     status, output = session.cmd_status_output(cmd)
     _process_status_output(cmd, status, output)
 
@@ -316,7 +323,7 @@ def remove(session, path, quote_path=True, flags="-fr"):
 
     Calls `rm -rf`.
     """
-    cmd = f'rm {flags} {quote(path)}' if quote_path else f'rm {flags} {path}'
+    cmd = f"rm {flags} {quote(path)}" if quote_path else f"rm {flags} {path}"
     status, output = session.cmd_status_output(cmd)
     _process_status_output(cmd, status, output)
 
@@ -335,7 +342,7 @@ def make_tempdir(session, template=None):
 
     Calls `mktemp -d`, refer to `man` for more info.
     """
-    cmd = f'mktemp -d {template}' if template is not None else 'mktemp -d'
+    cmd = f"mktemp -d {template}" if template is not None else "mktemp -d"
     status, output = session.cmd_status_output(cmd)
     _, output = _process_status_output(cmd, status, output)
     return output
@@ -355,7 +362,7 @@ def make_tempfile(session, template=None):
 
     Calls `mktemp`, refer to `man` for more info.
     """
-    cmd = f'mktemp {template}' if template is not None else 'mktemp'
+    cmd = f"mktemp {template}" if template is not None else "mktemp"
     status, output = session.cmd_status_output(cmd)
     _, output = _process_status_output(cmd, status, output)
     return output
@@ -377,7 +384,7 @@ def cat(session, filename, quote_path=True, flags=""):
     Should only be used for very small files without tabs or other fancy
     contents. Otherwise, it is better to download the file or use some other method.
     """
-    cmd = f'cat {flags} {quote(filename)}' if quote_path else f'cat {flags} {filename}'
+    cmd = f"cat {flags} {quote(filename)}" if quote_path else f"cat {flags} {filename}"
     status, output = session.cmd_status_output(cmd)
     _, output = _process_status_output(cmd, status, output)
     return output
@@ -463,15 +470,16 @@ def hash_file(session, filename, size="", method="md5"):
     if output:
         output = output.strip()
     if status != 0 or not output:
-        raise RuntimeError(f'Could not hash {filename} using {cmd}: {output}')
+        raise RuntimeError(f"Could not hash {filename} using {cmd}: {output}")
 
     # parse output
     hash_str = output.split(maxsplit=1)[0].lower()
 
     # check that all chars are hex
-    if hash_str.strip('0123456789abcdef'):
-        raise RuntimeError('Resulting hash string has unexpected characters: '
-                           + hash_str)
+    if hash_str.strip("0123456789abcdef"):
+        raise RuntimeError(
+            "Resulting hash string has unexpected characters: " + hash_str
+        )
     return hash_str
 
 
@@ -486,6 +494,6 @@ def extract_tarball(session, tarball, target_dir, flags="-ap"):
     :param str flags: extra flags passed to ``tar`` on the command line
     :raises: :py:class:`RuntimeError` if tar command returned non-null
     """
-    cmd = f'tar -C {quote(target_dir)} {flags} -xf {quote(tarball)}'
+    cmd = f"tar -C {quote(target_dir)} {flags} -xf {quote(tarball)}"
     status, output = session.cmd_status_output(cmd)
     _process_status_output(cmd, status, output)

--- a/aexpect/remote.py
+++ b/aexpect/remote.py
@@ -43,16 +43,15 @@ Example usage:
 # ..todo:: we could reduce the disabled issues after more significant refactoring
 
 from __future__ import division
+
 import logging
-import time
 import re
 import shlex
+import time
 
-from aexpect.client import Expect
-from aexpect.client import RemoteSession
-from aexpect.exceptions import ExpectTimeoutError
-from aexpect.exceptions import ExpectProcessTerminatedError
 from aexpect import rss_client
+from aexpect.client import Expect, RemoteSession
+from aexpect.exceptions import ExpectProcessTerminatedError, ExpectTimeoutError
 
 LOG = logging.getLogger(__name__)
 
@@ -69,7 +68,7 @@ class RemoteError(Exception):
 class LoginError(RemoteError):
     """Base class for any remote error related to logins and session creation."""
 
-    def __init__(self, msg, output=''):
+    def __init__(self, msg, output=""):
         super().__init__()
         self.msg = msg
         self.output = output
@@ -85,27 +84,26 @@ class LoginAuthenticationError(LoginError):
 class LoginTimeoutError(LoginError):
     """Remote error related to login timeout expiration."""
 
-    def __init__(self, output=''):
+    def __init__(self, output=""):
         super().__init__("Login timeout expired", output)
 
 
 class LoginProcessTerminatedError(LoginError):
     """Remote error related to login process termination."""
 
-    def __init__(self, status, output=''):
+    def __init__(self, status, output=""):
         super().__init__("Client process terminated", output)
         self.status = status
 
     def __str__(self):
-        return (f"{self.msg}    (status: {self.status},    "
-                f"output: {self.output!r})")
+        return f"{self.msg}    (status: {self.status},    " f"output: {self.output!r})"
 
 
 class LoginBadClientError(LoginError):
     """Remote error related to unknown remote shell client."""
 
     def __init__(self, client):
-        super().__init__('Unknown remote shell client')
+        super().__init__("Unknown remote shell client")
         self.client = client
 
     def __str__(self):
@@ -132,8 +130,10 @@ class TransferBadClientError(RemoteError):
         self.client = client
 
     def __str__(self):
-        return (f"Unknown file copy client: '{self.client}', "
-                "valid values are scp and rss")
+        return (
+            f"Unknown file copy client: '{self.client}', "
+            "valid values are scp and rss"
+        )
 
 
 class SCPError(TransferError):
@@ -166,8 +166,10 @@ class SCPTransferFailedError(SCPError):
         self.status = status
 
     def __str__(self):
-        return (f"SCP transfer failed    (status: {self.status},    "
-                f"output: {self.output!r})")
+        return (
+            f"SCP transfer failed    (status: {self.status},    "
+            f"output: {self.output!r})"
+        )
 
 
 class NetcatError(TransferError):
@@ -189,8 +191,10 @@ class NetcatTransferFailedError(NetcatError):
         self.status = status
 
     def __str__(self):
-        return (f"Netcat transfer failed    (status: {self.status},    "
-                f"output: {self.output!r})")
+        return (
+            f"Netcat transfer failed    (status: {self.status},    "
+            f"output: {self.output!r})"
+        )
 
 
 class NetcatTransferIntegrityError(NetcatError):
@@ -216,12 +220,13 @@ def quote_path(path):
     :return: Shell escaped version
     """
     if isinstance(path, list):
-        return ' '.join(map(shlex.quote, path))
+        return " ".join(map(shlex.quote, path))
     return shlex.quote(path)
 
 
-def handle_prompts(session, username, password, prompt=PROMPT_LINUX,
-                   timeout=10, debug=False):
+def handle_prompts(
+    session, username, password, prompt=PROMPT_LINUX, timeout=10, debug=False
+):
     """
     Connect to a remote host (guest) using SSH or Telnet or else.
 
@@ -252,18 +257,28 @@ def handle_prompts(session, username, password, prompt=PROMPT_LINUX,
     while True:
         try:
             match, text = session.read_until_last_line_matches(
-                [r"[Aa]re you sure", r"[Pp]assword:\s*",
-                 # Prompt of rescue mode for Red Hat.
-                 r"\(or (press|type) Control-D to continue\):\s*$",
-                 r"[Gg]ive.*[Ll]ogin:\s*$",  # Prompt of rescue mode for SUSE.
-                 r"(?<![Ll]ast )[Ll]ogin:\s*$",  # Don't match "Last Login:"
-                 r"[Cc]onnection.*closed", r"[Cc]onnection.*refused",
-                 r"[Pp]lease wait", r"[Ww]arning", r"[Ee]nter.*username",
-                 r"[Ee]nter.*password", r"[Cc]onnection timed out", prompt,
-                 r"Escape character is.*",
-                 r"Command>",
-                 r"[Ll]ost connection"],
-                timeout=timeout, internal_timeout=0.5)
+                [
+                    r"[Aa]re you sure",
+                    r"[Pp]assword:\s*",
+                    # Prompt of rescue mode for Red Hat.
+                    r"\(or (press|type) Control-D to continue\):\s*$",
+                    r"[Gg]ive.*[Ll]ogin:\s*$",  # Prompt of rescue mode for SUSE.
+                    r"(?<![Ll]ast )[Ll]ogin:\s*$",  # Don't match "Last Login:"
+                    r"[Cc]onnection.*closed",
+                    r"[Cc]onnection.*refused",
+                    r"[Pp]lease wait",
+                    r"[Ww]arning",
+                    r"[Ee]nter.*username",
+                    r"[Ee]nter.*password",
+                    r"[Cc]onnection timed out",
+                    prompt,
+                    r"Escape character is.*",
+                    r"Command>",
+                    r"[Ll]ost connection",
+                ],
+                timeout=timeout,
+                internal_timeout=0.5,
+            )
             output += text
             if match == 0:  # "Are you sure you want to continue connecting"
                 if debug:
@@ -272,18 +287,15 @@ def handle_prompts(session, username, password, prompt=PROMPT_LINUX,
             elif match in [1, 2, 3, 10]:  # "password:"
                 if password_prompt_count == 0:
                     if debug:
-                        LOG.debug("Got password prompt, sending '%s'",
-                                  password)
+                        LOG.debug("Got password prompt, sending '%s'", password)
                     session.sendline(password)
                     password_prompt_count += 1
                 else:
-                    raise LoginAuthenticationError("Got password prompt twice",
-                                                   text)
+                    raise LoginAuthenticationError("Got password prompt twice", text)
             elif match in [4, 9]:  # "login:"
                 if login_prompt_count == 0 and password_prompt_count == 0:
                     if debug:
-                        LOG.debug("Got username prompt; sending '%s'",
-                                  username)
+                        LOG.debug("Got username prompt; sending '%s'", username)
                     session.sendline(username)
                     login_prompt_count += 1
                 else:
@@ -316,15 +328,13 @@ def handle_prompts(session, username, password, prompt=PROMPT_LINUX,
                 session.sendline()
             elif match == 14:  # VMware vCenter command prompt
                 # Some old vsphere version (e.x. 6.0.0) needs to enable first.
-                cmd = 'shell.set --enabled True'
+                cmd = "shell.set --enabled True"
                 LOG.debug(
-                    "Got VMware VCenter prompt, "
-                    "send '%s' to enable shell first", cmd)
+                    "Got VMware VCenter prompt, send '%s' to enable shell first", cmd
+                )
                 session.sendline(cmd)
-                LOG.debug(
-                    "Got VMware VCenter prompt, "
-                    "send 'shell' to launch bash")
-                session.sendline('shell')
+                LOG.debug("Got VMware VCenter prompt, send 'shell' to launch bash")
+                session.sendline("shell")
         except ExpectTimeoutError as error:
             # sometimes, linux kernel print some message to console
             # the message maybe impact match login pattern, so send
@@ -341,13 +351,26 @@ def handle_prompts(session, username, password, prompt=PROMPT_LINUX,
     return output
 
 
-def remote_login(client, host, port, username, password, prompt, linesep="\n",
-                 log_filename=None, log_function=None, timeout=10,
-                 interface=None, identity_file=None,
-                 status_test_command="echo $?", verbose=False, bind_ip=None,
-                 preferred_authentication='password',
-                 user_known_hosts_file='/dev/null',
-                 extra_cmdline=''):
+def remote_login(
+    client,
+    host,
+    port,
+    username,
+    password,
+    prompt,
+    linesep="\n",
+    log_filename=None,
+    log_function=None,
+    timeout=10,
+    interface=None,
+    identity_file=None,
+    status_test_command="echo $?",
+    verbose=False,
+    bind_ip=None,
+    preferred_authentication="password",
+    user_known_hosts_file="/dev/null",
+    extra_cmdline="",
+):
     """
     Log into a remote host (guest) using SSH/Telnet/Netcat.
 
@@ -391,12 +414,13 @@ def remote_login(client, host, port, username, password, prompt, linesep="\n",
         extra_params.append(extra_cmdline)
     if host and host.lower().startswith("fe80"):
         if not interface:
-            raise RemoteError("When using ipv6 linklocal an interface must "
-                              "be assigned")
+            raise RemoteError("When using ipv6 linklocal an interface must be assigned")
         host = f"{host}%{interface}"
     if client == "ssh":
-        cmd = (f"ssh {' '.join(extra_params)} -o UserKnownHostsFile={user_known_hosts_file} "
-               f"-o StrictHostKeyChecking=no -p {port}")
+        cmd = (
+            f"ssh {' '.join(extra_params)} -o UserKnownHostsFile={user_known_hosts_file} "
+            f"-o StrictHostKeyChecking=no -p {port}"
+        )
         if bind_ip:
             cmd += f" -b {bind_ip}"
         if identity_file:
@@ -416,11 +440,20 @@ def remote_login(client, host, port, username, password, prompt, linesep="\n",
 
     if verbose:
         LOG.debug("Login command: '%s'", cmd)
-    session = RemoteSession(cmd, linesep=linesep, output_func=log_function,
-                            output_params=output_params, output_prefix=host,
-                            prompt=prompt, status_test_command=status_test_command,
-                            client=client, host=host, port=port,
-                            username=username, password=password)
+    session = RemoteSession(
+        cmd,
+        linesep=linesep,
+        output_func=log_function,
+        output_params=output_params,
+        output_prefix=host,
+        prompt=prompt,
+        status_test_command=status_test_command,
+        client=client,
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+    )
     try:
         handle_prompts(session, username, password, prompt, timeout)
     except Exception:
@@ -429,11 +462,22 @@ def remote_login(client, host, port, username, password, prompt, linesep="\n",
     return session
 
 
-def wait_for_login(client, host, port, username, password, prompt,
-                   linesep="\n", log_filename=None, log_function=None,
-                   timeout=240, internal_timeout=10, interface=None,
-                   preferred_authentication='password',
-                   user_known_hosts_file='/dev/null'):
+def wait_for_login(
+    client,
+    host,
+    port,
+    username,
+    password,
+    prompt,
+    linesep="\n",
+    log_filename=None,
+    log_function=None,
+    timeout=240,
+    internal_timeout=10,
+    interface=None,
+    preferred_authentication="password",
+    user_known_hosts_file="/dev/null",
+):
     """
     Make multiple attempts to log into a guest until one succeeds or timeouts.
 
@@ -460,31 +504,56 @@ def wait_for_login(client, host, port, username, password, prompt,
     :raise: Whatever remote_login() raises
     :return: A RemoteSession object.
     """
-    LOG.debug("Attempting to log into %s:%s using %s (timeout %ds)",
-              host, port, client, timeout)
+    LOG.debug(
+        "Attempting to log into %s:%s using %s (timeout %ds)",
+        host,
+        port,
+        client,
+        timeout,
+    )
     end_time = time.time() + timeout
     verbose = False
     while time.time() < end_time:
         try:
-            return remote_login(client, host, port, username, password, prompt,
-                                linesep, log_filename, log_function,
-                                internal_timeout, interface, verbose=verbose,
-                                preferred_authentication=preferred_authentication,
-                                user_known_hosts_file=user_known_hosts_file)
+            return remote_login(
+                client,
+                host,
+                port,
+                username,
+                password,
+                prompt,
+                linesep,
+                log_filename,
+                log_function,
+                internal_timeout,
+                interface,
+                verbose=verbose,
+                preferred_authentication=preferred_authentication,
+                user_known_hosts_file=user_known_hosts_file,
+            )
         except LoginError as error:
             LOG.debug(error)
             verbose = True
         time.sleep(2)
     # Timeout expired; try one more time but don't catch exceptions
-    return remote_login(client, host, port, username, password, prompt,
-                        linesep, log_filename, log_function,
-                        internal_timeout, interface,
-                        preferred_authentication=preferred_authentication,
-                        user_known_hosts_file=user_known_hosts_file)
+    return remote_login(
+        client,
+        host,
+        port,
+        username,
+        password,
+        prompt,
+        linesep,
+        log_filename,
+        log_function,
+        internal_timeout,
+        interface,
+        preferred_authentication=preferred_authentication,
+        user_known_hosts_file=user_known_hosts_file,
+    )
 
 
-def _remote_scp(
-        session, password_list, transfer_timeout=600, login_timeout=300):
+def _remote_scp(session, password_list, transfer_timeout=600, login_timeout=300):
     """
     Transfer files using SCP, given a command line.
 
@@ -516,29 +585,34 @@ def _remote_scp(
         try:
             match, text = session.read_until_last_line_matches(
                 [r"[Aa]re you sure", r"[Pp]assword:\s*$", r"lost connection"],
-                timeout=timeout, internal_timeout=0.5)
+                timeout=timeout,
+                internal_timeout=0.5,
+            )
             if match == 0:  # "Are you sure you want to continue connecting"
                 LOG.debug("Got 'Are you sure...', sending 'yes'")
                 session.sendline("yes")
             elif match == 1:  # "password:"
                 if password_prompt_count == 0:
-                    LOG.debug("Got password prompt, sending '%s'",
-                              password_list[password_prompt_count])
+                    LOG.debug(
+                        "Got password prompt, sending '%s'",
+                        password_list[password_prompt_count],
+                    )
                     session.sendline(password_list[password_prompt_count])
                     password_prompt_count += 1
                     timeout = transfer_timeout
                     if scp_type == 1:
                         authentication_done = True
                 elif password_prompt_count == 1 and scp_type == 2:
-                    LOG.debug("Got password prompt, sending '%s'",
-                              password_list[password_prompt_count])
+                    LOG.debug(
+                        "Got password prompt, sending '%s'",
+                        password_list[password_prompt_count],
+                    )
                     session.sendline(password_list[password_prompt_count])
                     password_prompt_count += 1
                     timeout = transfer_timeout
                     authentication_done = True
                 else:
-                    raise SCPAuthenticationError("Got password prompt twice",
-                                                 text)
+                    raise SCPAuthenticationError("Got password prompt twice", text)
             elif match == 2:  # "lost connection"
                 raise SCPError("SCP client said 'lost connection'", text)
         except ExpectTimeoutError as error:
@@ -552,8 +626,14 @@ def _remote_scp(
             raise SCPTransferFailedError(error.status, error.output) from error
 
 
-def remote_scp(command, password_list, log_filename=None, log_function=None,
-               transfer_timeout=600, login_timeout=300):
+def remote_scp(
+    command,
+    password_list,
+    log_filename=None,
+    log_function=None,
+    transfer_timeout=600,
+    login_timeout=300,
+):
     """
     Transfer files using SCP, given a command line.
 
@@ -569,22 +649,33 @@ def remote_scp(command, password_list, log_filename=None, log_function=None,
             or the password prompt)
     :raise: Whatever _remote_scp() raises
     """
-    LOG.debug("Trying to SCP with command '%s', timeout %ss",
-              command, transfer_timeout)
+    LOG.debug("Trying to SCP with command '%s', timeout %ss", command, transfer_timeout)
     if log_filename:
         output_func = log_function
         output_params = (log_filename,)
     else:
         output_func = None
         output_params = ()
-    with Expect(command, output_func=output_func,
-                output_params=output_params) as session:
+    with Expect(
+        command, output_func=output_func, output_params=output_params
+    ) as session:
         _remote_scp(session, password_list, transfer_timeout, login_timeout)
 
 
-def scp_to_remote(host, port, username, password, local_path, remote_path,
-                  limit="", log_filename=None, log_function=None,
-                  timeout=600, interface=None, directory=True):
+def scp_to_remote(
+    host,
+    port,
+    username,
+    password,
+    local_path,
+    remote_path,
+    limit="",
+    log_filename=None,
+    log_function=None,
+    timeout=600,
+    interface=None,
+    directory=True,
+):
     """
     Copy files to a remote host (guest) through scp.
 
@@ -609,26 +700,40 @@ def scp_to_remote(host, port, username, password, local_path, remote_path,
 
     if host and host.lower().startswith("fe80"):
         if not interface:
-            raise SCPError("When using ipv6 linklocal address must assign",
-                           "the interface the neighbour attache")
+            raise SCPError(
+                "When using ipv6 linklocal address must assign",
+                "the interface the neighbour attache",
+            )
         host = f"{host}%{interface}"
 
     command = "scp"
     if directory:
         command = f"{command} -r"
-    command += (r" -v -o UserKnownHostsFile=/dev/null "
-                r"-o StrictHostKeyChecking=no "
-                fr"-o PreferredAuthentications=password {limit} "
-                fr"-P {port} {quote_path(local_path)} {username}@\[{host}\]:"
-                fr"{shlex.quote(remote_path)}")
+    command += (
+        r" -v -o UserKnownHostsFile=/dev/null "
+        r"-o StrictHostKeyChecking=no "
+        rf"-o PreferredAuthentications=password {limit} "
+        rf"-P {port} {quote_path(local_path)} {username}@\[{host}\]:"
+        rf"{shlex.quote(remote_path)}"
+    )
     password_list = [password]
-    return remote_scp(command, password_list,
-                      log_filename, log_function, timeout)
+    return remote_scp(command, password_list, log_filename, log_function, timeout)
 
 
-def scp_from_remote(host, port, username, password, remote_path, local_path,
-                    limit="", log_filename=None, log_function=None,
-                    timeout=600, interface=None, directory=True):
+def scp_from_remote(
+    host,
+    port,
+    username,
+    password,
+    remote_path,
+    local_path,
+    limit="",
+    log_filename=None,
+    log_function=None,
+    timeout=600,
+    interface=None,
+    directory=True,
+):
     """
     Copy files from a remote host (guest).
 
@@ -652,27 +757,44 @@ def scp_from_remote(host, port, username, password, remote_path, local_path,
         limit = f"-l {limit}"
     if host and host.lower().startswith("fe80"):
         if not interface:
-            raise SCPError("When using ipv6 linklocal address must assign, ",
-                           "the interface the neighbour attache")
+            raise SCPError(
+                "When using ipv6 linklocal address must assign, ",
+                "the interface the neighbour attache",
+            )
         host = f"{host}%{interface}"
 
     command = "scp"
     if directory:
         command = f"{command} -r"
-    command += (r" -v -o UserKnownHostsFile=/dev/null "
-                r"-o StrictHostKeyChecking=no "
-                fr"-o PreferredAuthentications=password {limit} "
-                fr"-P {port} {username}@\[{host}\]:{quote_path(remote_path)} "
-                fr"{shlex.quote(local_path)}")
+    command += (
+        r" -v -o UserKnownHostsFile=/dev/null "
+        r"-o StrictHostKeyChecking=no "
+        rf"-o PreferredAuthentications=password {limit} "
+        rf"-P {port} {username}@\[{host}\]:{quote_path(remote_path)} "
+        rf"{shlex.quote(local_path)}"
+    )
     password_list = [password]
-    remote_scp(command, password_list,
-               log_filename, log_function, timeout)
+    remote_scp(command, password_list, log_filename, log_function, timeout)
 
 
-def scp_between_remotes(src, dst, port, s_passwd, d_passwd, s_name, d_name,
-                        s_path, d_path, limit="",
-                        log_filename=None, log_function=None, timeout=600,
-                        src_inter=None, dst_inter=None, directory=True):
+def scp_between_remotes(
+    src,
+    dst,
+    port,
+    s_passwd,
+    d_passwd,
+    s_name,
+    d_name,
+    s_path,
+    d_path,
+    limit="",
+    log_filename=None,
+    log_function=None,
+    timeout=600,
+    src_inter=None,
+    dst_inter=None,
+    directory=True,
+):
     """
     Copy files from a remote host (guest) to another remote host (guest).
 
@@ -700,35 +822,54 @@ def scp_between_remotes(src, dst, port, s_passwd, d_passwd, s_name, d_name,
         limit = f"-l {limit}"
     if src and src.lower().startswith("fe80"):
         if not src_inter:
-            raise SCPError("When using ipv6 linklocal address must assign ",
-                           "the interface the neighbour attache")
+            raise SCPError(
+                "When using ipv6 linklocal address must assign ",
+                "the interface the neighbour attache",
+            )
         src = f"{src}%{src_inter}"
     if dst and dst.lower().startswith("fe80"):
         if not dst_inter:
-            raise SCPError("When using ipv6 linklocal address must assign ",
-                           "the interface the neighbour attache")
+            raise SCPError(
+                "When using ipv6 linklocal address must assign ",
+                "the interface the neighbour attache",
+            )
         dst = f"{dst}%{dst_inter}"
 
     command = "scp"
     if directory:
         command = f"{command} -r"
-    command += (r" -v -o UserKnownHostsFile=/dev/null "
-                r"-o StrictHostKeyChecking=no "
-                fr"-o PreferredAuthentications=password {limit} -P {port}"
-                fr" {s_name}@\[{src}\]:{quote_path(s_path)} {d_name}@\[{dst}\]"
-                fr":{shlex.quote(d_path)}")
+    command += (
+        r" -v -o UserKnownHostsFile=/dev/null "
+        r"-o StrictHostKeyChecking=no "
+        rf"-o PreferredAuthentications=password {limit} -P {port}"
+        rf" {s_name}@\[{src}\]:{quote_path(s_path)} {d_name}@\[{dst}\]"
+        rf":{shlex.quote(d_path)}"
+    )
     password_list = [s_passwd, d_passwd]
-    return remote_scp(command, password_list,
-                      log_filename, log_function, timeout)
+    return remote_scp(command, password_list, log_filename, log_function, timeout)
 
 
 # noinspection PyBroadException
-def nc_copy_between_remotes(src, dst, s_port, s_passwd, d_passwd,
-                            s_name, d_name, s_path, d_path,
-                            c_type="ssh", c_prompt="\n",
-                            d_port="8888", d_protocol="tcp", timeout=2,
-                            check_sum=True, s_session=None,
-                            d_session=None, file_transfer_timeout=600):
+def nc_copy_between_remotes(
+    src,
+    dst,
+    s_port,
+    s_passwd,
+    d_passwd,
+    s_name,
+    d_name,
+    s_path,
+    d_path,
+    c_type="ssh",
+    c_prompt="\n",
+    d_port="8888",
+    d_protocol="tcp",
+    timeout=2,
+    check_sum=True,
+    s_session=None,
+    d_session=None,
+    file_transfer_timeout=600,
+):
     """
     Copy files from guest to guest using netcat.
 
@@ -758,19 +899,9 @@ def nc_copy_between_remotes(src, dst, s_port, s_passwd, d_passwd,
     """
     check_string = "NCFT"
     if not s_session:
-        s_session = remote_login(c_type,
-                                 src,
-                                 s_port,
-                                 s_name,
-                                 s_passwd,
-                                 c_prompt)
+        s_session = remote_login(c_type, src, s_port, s_name, s_passwd, c_prompt)
     if not d_session:
-        d_session = remote_login(c_type,
-                                 dst,
-                                 s_port,
-                                 d_name,
-                                 d_passwd,
-                                 c_prompt)
+        d_session = remote_login(c_type, dst, s_port, d_name, d_passwd, c_prompt)
 
     try:
         s_session.cmd(f"iptables -I INPUT -p {d_protocol} -j ACCEPT")
@@ -786,12 +917,12 @@ def nc_copy_between_remotes(src, dst, s_port, s_passwd, d_passwd,
     d_session.sendline(receive_cmd)
     send_cmd = f"{cmd} {dst} {d_port} < {s_path}"
     status, output = s_session.cmd_status_output(
-        send_cmd, timeout=file_transfer_timeout)
+        send_cmd, timeout=file_transfer_timeout
+    )
     if status:
         err = f"Fail to transfer file between {src} -> {dst}."
         if check_string not in output:
-            err += ("src did not receive check "
-                    f"string {check_string} sent by dst.")
+            err += "src did not receive check " f"string {check_string} sent by dst."
         err += f"send nc command {send_cmd}, output {output}"
         err += f"Receive nc command {receive_cmd}."
         raise NetcatTransferFailedError(status, err)
@@ -802,17 +933,30 @@ def nc_copy_between_remotes(src, dst, s_port, s_passwd, d_passwd,
         src_md5 = output.split()[0]
         dst_md5 = d_session.cmd(f"md5sum {d_path}").split()[0]
         if src_md5.strip() != dst_md5.strip():
-            err_msg = ("Files md5sum mismatch, "
-                       f"file {s_path} md5sum is '{src_md5}', "
-                       f"but the file {d_path} md5sum is {dst_md5}")
+            err_msg = (
+                "Files md5sum mismatch, "
+                f"file {s_path} md5sum is '{src_md5}', "
+                f"but the file {d_path} md5sum is {dst_md5}"
+            )
             raise NetcatTransferIntegrityError(err_msg)
     return True
 
 
-def udp_copy_between_remotes(src, dst, s_port, s_passwd, d_passwd,
-                             s_name, d_name, s_path, d_path,
-                             c_type="ssh", c_prompt="\n",
-                             d_port="9000", timeout=600):
+def udp_copy_between_remotes(
+    src,
+    dst,
+    s_port,
+    s_passwd,
+    d_passwd,
+    s_name,
+    d_name,
+    s_path,
+    d_path,
+    c_type="ssh",
+    c_prompt="\n",
+    d_port="9000",
+    timeout=600,
+):
     """
     Copy files from guest to guest using udp.
 
@@ -839,23 +983,21 @@ def udp_copy_between_remotes(src, dst, s_port, s_passwd, d_passwd,
         cmd_tmp += "extension='%s'\" get drive^,path"
         cmd = cmd_tmp % (filename, extension)
         info = session.cmd_output(cmd, timeout=360).strip()
-        drive_path = re.search(r'(\w):\s+(\S+)', info, re.M)
+        drive_path = re.search(r"(\w):\s+(\S+)", info, re.M)
         if not drive_path:
-            raise UDPError(f"Not found file {filename}.{extension} "
-                           "in your guest")
+            raise UDPError(f"Not found file {filename}.{extension} " "in your guest")
         return ":".join(drive_path.groups())
 
     def get_file_md5(session, file_path):
         """Get files md5sums."""
         if c_type == "ssh":
             md5_cmd = f"md5sum {file_path}"
-            md5_reg = fr"(\w+)\s+{file_path}.*"
+            md5_reg = rf"(\w+)\s+{file_path}.*"
         else:
             drive_path = get_abs_path(session, "md5sums", "exe")
             filename = file_path.split("\\")[-1]
-            md5_reg = fr"{filename}\s+(\w+)"
-            md5_cmd = (f'{drive_path}md5sums.exe {file_path} | '
-                       f'find "{filename}"')
+            md5_reg = rf"{filename}\s+(\w+)"
+            md5_cmd = f"{drive_path}md5sums.exe {file_path} | " f'find "{filename}"'
         output = session.cmd_output(md5_cmd)
         file_md5 = re.findall(md5_reg, output)
         if not output:
@@ -893,9 +1035,13 @@ def udp_copy_between_remotes(src, dst, s_port, s_passwd, d_passwd,
         else:
             drive_path = get_abs_path(session, "recvfile", "exe")
             client_cmd_tmp = "%srecvfile.exe %s %s %s %s"
-            client_cmd = client_cmd_tmp % (drive_path, src, d_port,
-                                           s_path.split("\\")[-1],
-                                           d_path.split("\\")[-1])
+            client_cmd = client_cmd_tmp % (
+                drive_path,
+                src,
+                d_port,
+                s_path.split("\\")[-1],
+                d_path.split("\\")[-1],
+            )
         session.cmd_output_safe(client_cmd, timeout)
 
     def stop_server(session):
@@ -914,9 +1060,11 @@ def udp_copy_between_remotes(src, dst, s_port, s_passwd, d_passwd,
         start_client(d_session)
         dst_md5 = get_file_md5(d_session, d_path)
         if src_md5 != dst_md5:
-            err_msg = ("Files md5sum mismatch, "
-                       f"file {s_path} md5sum is '{src_md5}', "
-                       f"but the file {d_path} md5sum is {dst_md5}")
+            err_msg = (
+                "Files md5sum mismatch, "
+                f"file {s_path} md5sum is '{src_md5}', "
+                f"but the file {d_path} md5sum is {dst_md5}"
+            )
             raise UDPError(err_msg)
     finally:
         stop_server(s_session)
@@ -924,8 +1072,14 @@ def udp_copy_between_remotes(src, dst, s_port, s_passwd, d_passwd,
         d_session.close()
 
 
-def login_from_session(session, log_filename=None, log_function=None,
-                       timeout=240, internal_timeout=10, interface=None):
+def login_from_session(
+    session,
+    log_filename=None,
+    log_function=None,
+    timeout=240,
+    internal_timeout=10,
+    interface=None,
+):
     """
     Log in remotely and return a session for the connection with the same
     configuration as a previous session.
@@ -942,16 +1096,33 @@ def login_from_session(session, log_filename=None, log_function=None,
 
     The rest of the arguments are identical to wait_for_login().
     """
-    return wait_for_login(session.client, session.host, session.port,
-                          session.username, session.password,
-                          session.prompt, session.linesep,
-                          log_filename, log_function,
-                          timeout, internal_timeout, interface)
+    return wait_for_login(
+        session.client,
+        session.host,
+        session.port,
+        session.username,
+        session.password,
+        session.prompt,
+        session.linesep,
+        log_filename,
+        log_function,
+        timeout,
+        internal_timeout,
+        interface,
+    )
 
 
-def scp_to_session(session, local_path, remote_path,
-                   limit="", log_filename=None, log_function=None,
-                   timeout=600, interface=None, directory=True):
+def scp_to_session(
+    session,
+    local_path,
+    remote_path,
+    limit="",
+    log_filename=None,
+    log_function=None,
+    timeout=600,
+    interface=None,
+    directory=True,
+):
     """
     Secure copy a filepath (w/o wildcard) to a remote location with the same
     configuration as a previous session.
@@ -969,16 +1140,33 @@ def scp_to_session(session, local_path, remote_path,
 
     The rest of the arguments are identical to scp_to_remote().
     """
-    scp_to_remote(session.host, session.port,
-                  session.username, session.password,
-                  local_path, remote_path,
-                  limit, log_filename, log_function,
-                  timeout, interface, directory)
+    scp_to_remote(
+        session.host,
+        session.port,
+        session.username,
+        session.password,
+        local_path,
+        remote_path,
+        limit,
+        log_filename,
+        log_function,
+        timeout,
+        interface,
+        directory,
+    )
 
 
-def scp_from_session(session, remote_path, local_path,
-                     limit="", log_filename=None, log_function=None,
-                     timeout=600, interface=None, directory=True):
+def scp_from_session(
+    session,
+    remote_path,
+    local_path,
+    limit="",
+    log_filename=None,
+    log_function=None,
+    timeout=600,
+    interface=None,
+    directory=True,
+):
     """
     Secure copy a filepath (w/o wildcard) from a remote location with the same
     configuration as a previous session.
@@ -996,11 +1184,20 @@ def scp_from_session(session, remote_path, local_path,
 
     The rest of the arguments are identical to scp_from_remote().
     """
-    scp_from_remote(session.host, session.port,
-                    session.username, session.password,
-                    remote_path, local_path,
-                    limit, log_filename, log_function,
-                    timeout, interface, directory)
+    scp_from_remote(
+        session.host,
+        session.port,
+        session.username,
+        session.password,
+        remote_path,
+        local_path,
+        limit,
+        log_filename,
+        log_function,
+        timeout,
+        interface,
+        directory,
+    )
 
 
 def throughput_transfer(func):
@@ -1031,10 +1228,23 @@ def throughput_transfer(func):
 
 # noinspection PyUnusedLocal
 @throughput_transfer
-def copy_files_to(address, client, username, password, port, local_path,
-                  remote_path, limit="", log_filename=None, log_function=None,
-                  verbose=False, timeout=600, interface=None, filesize=None,  # pylint: disable=unused-argument
-                  directory=True):
+def copy_files_to(
+    address,
+    client,
+    username,
+    password,
+    port,
+    local_path,
+    remote_path,
+    limit="",
+    log_filename=None,
+    log_function=None,
+    verbose=False,
+    timeout=600,
+    interface=None,
+    filesize=None,  # pylint: disable=unused-argument
+    directory=True,
+):
     """
     Copy files to a remote host (guest) using the selected client.
 
@@ -1058,9 +1268,20 @@ def copy_files_to(address, client, username, password, port, local_path,
     :raise: Whatever remote_scp() raises
     """
     if client == "scp":
-        scp_to_remote(address, port, username, password, local_path,
-                      remote_path, limit, log_filename, log_function, timeout,
-                      interface=interface, directory=directory)
+        scp_to_remote(
+            address,
+            port,
+            username,
+            password,
+            local_path,
+            remote_path,
+            limit,
+            log_filename,
+            log_function,
+            timeout,
+            interface=interface,
+            directory=directory,
+        )
     elif client == "rss":
         log_func = None
         if verbose:
@@ -1076,10 +1297,23 @@ def copy_files_to(address, client, username, password, port, local_path,
 
 # noinspection PyUnusedLocal
 @throughput_transfer
-def copy_files_from(address, client, username, password, port, remote_path,
-                    local_path, limit="", log_filename=None, log_function=None,
-                    verbose=False, timeout=600, interface=None, filesize=None,  # pylint: disable=unused-argument
-                    directory=True):
+def copy_files_from(
+    address,
+    client,
+    username,
+    password,
+    port,
+    remote_path,
+    local_path,
+    limit="",
+    log_filename=None,
+    log_function=None,
+    verbose=False,
+    timeout=600,
+    interface=None,
+    filesize=None,  # pylint: disable=unused-argument
+    directory=True,
+):
     """
     Copy files from a remote host (guest) using the selected client.
 
@@ -1103,9 +1337,20 @@ def copy_files_from(address, client, username, password, port, remote_path,
     :raise: Whatever ``remote_scp()`` raises
     """
     if client == "scp":
-        scp_from_remote(address, port, username, password, remote_path,
-                        local_path, limit, log_filename, log_function, timeout,
-                        interface=interface, directory=directory)
+        scp_from_remote(
+            address,
+            port,
+            username,
+            password,
+            remote_path,
+            local_path,
+            limit,
+            log_filename,
+            log_function,
+            timeout,
+            interface=interface,
+            directory=directory,
+        )
     elif client == "rss":
         log_func = None
         if verbose:

--- a/aexpect/rss_client.py
+++ b/aexpect/rss_client.py
@@ -25,13 +25,14 @@ Client for file transfer services offered by RSS (Remote Shell Server).
 # ..todo:: we could reduce the disabled issues after more significant refactoring
 
 from __future__ import division, print_function
+
+import argparse
+import glob
+import os
 import socket
 import struct
-import time
 import sys
-import os
-import glob
-import argparse
+import time
 
 # Globals
 CHUNKSIZE = 65536
@@ -63,8 +64,7 @@ class FileTransferError(Exception):
     def __str__(self):
         errmsg = self.msg
         if self.error and self.filename:
-            errmsg += (f"    (error: {self.error},"
-                       f"    filename: {self.filename})")
+            errmsg += f"    (error: {self.error}," f"    filename: {self.filename})"
         elif self.error:
             errmsg += f"    ({self.error})"
         elif self.filename:
@@ -122,24 +122,25 @@ class FileTransferClient:
         :param timeout: Time duration to wait for connection to succeed
         :raise FileTransferConnectError: Raised if the connection fails
         """
-        family = socket.AF_INET6 if ':' in address else socket.AF_INET
+        family = socket.AF_INET6 if ":" in address else socket.AF_INET
         self._socket = socket.socket(family, socket.SOCK_STREAM)
         self._socket.settimeout(timeout)
         try:
-            addrinfo = socket.getaddrinfo(address, port, family,
-                                          socket.SOCK_STREAM,
-                                          socket.IPPROTO_TCP)
+            addrinfo = socket.getaddrinfo(
+                address, port, family, socket.SOCK_STREAM, socket.IPPROTO_TCP
+            )
             self._socket.connect(addrinfo[0][4])
         except socket.error as error:
-            raise FileTransferConnectError("Cannot connect to server at "
-                                           f"{address}:{port}",
-                                           error) from error
+            raise FileTransferConnectError(
+                "Cannot connect to server at " f"{address}:{port}", error
+            ) from error
         try:
             if self._receive_msg(timeout) != RSS_MAGIC:
                 raise FileTransferConnectError("Received wrong magic number")
         except FileTransferTimeoutError as timeout_error:
-            raise FileTransferConnectError("Timeout expired while waiting to "
-                                           "receive magic number") from timeout_error
+            raise FileTransferConnectError(
+                "Timeout expired while waiting to receive magic number"
+            ) from timeout_error
         self._send(struct.pack("=i", CHUNKSIZE))
         self._log_func = log_func
         self._last_time = time.time()
@@ -162,11 +163,13 @@ class FileTransferClient:
             self._socket.settimeout(timeout)
             self._socket.sendall(data)
         except socket.timeout as error:
-            raise FileTransferTimeoutError("Timeout expired while sending "
-                                           "data to server") from error
+            raise FileTransferTimeoutError(
+                "Timeout expired while sending data to server"
+            ) from error
         except socket.error as error:
-            raise FileTransferSocketError("Could not send data to server",
-                                          error) from error
+            raise FileTransferSocketError(
+                "Could not send data to server", error
+            ) from error
 
     def _receive(self, size, timeout=60):
         strs = []
@@ -179,29 +182,32 @@ class FileTransferClient:
                 self._socket.settimeout(timeout)
                 data = self._socket.recv(size)
                 if not data:
-                    raise FileTransferProtocolError("Connection closed "
-                                                    "unexpectedly while "
-                                                    "receiving data from "
-                                                    "server")
+                    raise FileTransferProtocolError(
+                        "Connection closed "
+                        "unexpectedly while "
+                        "receiving data from "
+                        "server"
+                    )
                 strs.append(data)
                 size -= len(data)
         except socket.timeout as error:
-            raise FileTransferTimeoutError("Timeout expired while receiving "
-                                           "data from server") from error
+            raise FileTransferTimeoutError(
+                "Timeout expired while receiving data from server"
+            ) from error
         except socket.error as error:
-            raise FileTransferSocketError("Error receiving data from server",
-                                          error) from error
+            raise FileTransferSocketError(
+                "Error receiving data from server", error
+            ) from error
         return b"".join(strs)
 
     def _report_stats(self, data):
         if self._log_func:
             delta = time.time() - self._last_time
             if delta >= 1:
-                transferred = self.transferred / 1048576.
+                transferred = self.transferred / 1048576.0
                 speed = (self.transferred - self._last_transferred) / delta
-                speed /= 1048576.
-                self._log_func(f"{data} {transferred:.3f} MB ({speed:.3f}"
-                               " MB/sec)")
+                speed /= 1048576.0
+                self._log_func(f"{data} {transferred:.3f} MB ({speed:.3f}" " MB/sec)")
                 self._last_time = time.time()
                 self._last_transferred = self.transferred
 
@@ -358,9 +364,11 @@ class FileUploadClient(FileTransferClient):
             else:
                 # If nothing was transferred, raise an exception
                 if not matches:
-                    raise FileTransferNotFoundError(f"Pattern {src_pattern} "
-                                                    "does not match any files "
-                                                    "or directories")
+                    raise FileTransferNotFoundError(
+                        f"Pattern {src_pattern} "
+                        "does not match any files "
+                        "or directories"
+                    )
                 # Look for RSS_OK or RSS_ERROR
                 msg = self._receive_msg(int(end_time - time.time()))
                 if msg == RSS_OK:
@@ -473,7 +481,8 @@ class FileDownloadClient(FileTransferClient):
                     if not file_count and not dir_count:
                         raise FileTransferNotFoundError(
                             f"Pattern {src_pattern} does not match any files "
-                            "or directories that could be downloaded")
+                            "or directories that could be downloaded"
+                        )
                     break
                 elif msg == RSS_ERROR:
                     # Receive error message and abort
@@ -488,8 +497,9 @@ class FileDownloadClient(FileTransferClient):
             raise
 
 
-def upload(address, port, src_pattern, dst_path, log_func=None, timeout=60,
-           connect_timeout=20):
+def upload(
+    address, port, src_pattern, dst_path, log_func=None, timeout=60, connect_timeout=20
+):
     """
     Connect to server and upload files.
 
@@ -500,8 +510,9 @@ def upload(address, port, src_pattern, dst_path, log_func=None, timeout=60,
     client.close()
 
 
-def download(address, port, src_pattern, dst_path, log_func=None, timeout=60,
-             connect_timeout=20):
+def download(
+    address, port, src_pattern, dst_path, log_func=None, timeout=60, connect_timeout=20
+):
     """
     Connect to server and upload files.
 
@@ -520,18 +531,31 @@ def main():
     parser.add_argument("port")
     parser.add_argument("src_pattern")
     parser.add_argument("dst_path")
-    parser.add_argument("-d", "--download",
-                        action="store_true", dest="download",
-                        help="download files from server")
-    parser.add_argument("-u", "--upload",
-                        action="store_true", dest="upload",
-                        help="upload files to server")
-    parser.add_argument("-v", "--verbose",
-                        action="store_true", dest="verbose",
-                        help="be verbose")
-    parser.add_argument("-t", "--timeout",
-                        type=int, dest="timeout", default=3600,
-                        help="transfer timeout")
+    parser.add_argument(
+        "-d",
+        "--download",
+        action="store_true",
+        dest="download",
+        help="download files from server",
+    )
+    parser.add_argument(
+        "-u",
+        "--upload",
+        action="store_true",
+        dest="upload",
+        help="upload files to server",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", dest="verbose", help="be verbose"
+    )
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        type=int,
+        dest="timeout",
+        default=3600,
+        help="transfer timeout",
+    )
     args = parser.parse_args()
     if args.download == args.upload:
         parser.error("you must specify either -d or -u")

--- a/aexpect/shared.py
+++ b/aexpect/shared.py
@@ -11,11 +11,11 @@
 
 """Some shared functions"""
 
-import os
 import fcntl
+import os
 import termios
 
-BASE_DIR = os.environ.get('TMPDIR', '/tmp')
+BASE_DIR = os.environ.get("TMPDIR", "/tmp")
 
 
 def get_lock_fd(filename):
@@ -59,14 +59,22 @@ def wait_for_lock(filename):
 def makeraw(shell_fd):
     """Turn console into 'raw' format"""
     attr = termios.tcgetattr(shell_fd)
-    attr[0] &= ~(termios.IGNBRK | termios.BRKINT | termios.PARMRK |
-                 termios.ISTRIP | termios.INLCR | termios.IGNCR |
-                 termios.ICRNL | termios.IXON)
+    attr[0] &= ~(
+        termios.IGNBRK
+        | termios.BRKINT
+        | termios.PARMRK
+        | termios.ISTRIP
+        | termios.INLCR
+        | termios.IGNCR
+        | termios.ICRNL
+        | termios.IXON
+    )
     attr[1] &= ~termios.OPOST
     attr[2] &= ~(termios.CSIZE | termios.PARENB)
     attr[2] |= termios.CS8
-    attr[3] &= ~(termios.ECHO | termios.ECHONL | termios.ICANON |
-                 termios.ISIG | termios.IEXTEN)
+    attr[3] &= ~(
+        termios.ECHO | termios.ECHONL | termios.ICANON | termios.ISIG | termios.IEXTEN
+    )
     termios.tcsetattr(shell_fd, termios.TCSANOW, attr)
 
 
@@ -86,9 +94,16 @@ def makestandard(shell_fd, echo):
 
 def get_filenames(base_dir):
     """Get paths to files produced by aexpect in it's working dir"""
-    files = ("shell-pid", "status", "output", "inpipe", "ctrlpipe",
-             "lock-server-running", "lock-client-starting",
-             "server-log")
+    files = (
+        "shell-pid",
+        "status",
+        "output",
+        "inpipe",
+        "ctrlpipe",
+        "lock-server-running",
+        "lock-client-starting",
+        "server-log",
+    )
     return [os.path.join(base_dir, s) for s in files]
 
 

--- a/aexpect/utils/astring.py
+++ b/aexpect/utils/astring.py
@@ -42,8 +42,7 @@ def strip_console_codes(output, custom_codes=None):
     while index < len(output):
         tmp_index = 0
         tmp_word = ""
-        while (len(re.findall("\x1b", tmp_word)) < 2 and
-               index + tmp_index < len(output)):
+        while len(re.findall("\x1b", tmp_word)) < 2 and index + tmp_index < len(output):
             tmp_word += output[index + tmp_index]
             tmp_index += 1
 
@@ -55,12 +54,14 @@ def strip_console_codes(output, custom_codes=None):
             special_code = re.findall(console_codes, tmp_word)[0]
         except IndexError as error:
             if index + tmp_index < len(output):
-                raise ValueError(f"{tmp_word} is not included in the known "
-                                 "console codes list "
-                                 f"{console_codes}") from error
+                raise ValueError(
+                    f"{tmp_word} is not included in the known "
+                    "console codes list "
+                    f"{console_codes}"
+                ) from error
             continue
         if special_code == tmp_word:
             continue
         old_word = tmp_word
-        return_str += tmp_word[len(special_code):]
+        return_str += tmp_word[len(special_code) :]
     return return_str

--- a/aexpect/utils/data_factory.py
+++ b/aexpect/utils/data_factory.py
@@ -17,8 +17,7 @@ import string
 _RAND_POOL = random.SystemRandom()
 
 
-def generate_random_string(length, ignore=string.punctuation,
-                           convert=""):
+def generate_random_string(length, ignore=string.punctuation, convert=""):
     """
     Generate a random string using alphanumeric characters.
 

--- a/aexpect/utils/path.py
+++ b/aexpect/utils/path.py
@@ -29,8 +29,10 @@ class CmdNotFoundError(Exception):
         self.paths = paths
 
     def __str__(self):
-        return (f"Command '{self.cmd}' could not be found in any of the PATH "
-                f"dirs: {self.paths}")
+        return (
+            f"Command '{self.cmd}' could not be found in any of the PATH "
+            f"dirs: {self.paths}"
+        )
 
 
 def find_command(cmd, default=None):
@@ -44,12 +46,19 @@ def find_command(cmd, default=None):
             command was not found and no default was given.
     """
     try:
-        path_paths = os.environ['PATH'].split(":")
+        path_paths = os.environ["PATH"].split(":")
     except IndexError:
         path_paths = []
 
-    for common_path in ["/usr/libexec", "/usr/local/sbin", "/usr/local/bin",
-                        "/usr/sbin", "/usr/bin", "/sbin", "/bin"]:
+    for common_path in [
+        "/usr/libexec",
+        "/usr/local/sbin",
+        "/usr/local/bin",
+        "/usr/sbin",
+        "/usr/bin",
+        "/sbin",
+        "/bin",
+    ]:
         if common_path not in path_paths:
             path_paths.append(common_path)
 

--- a/aexpect/utils/process.py
+++ b/aexpect/utils/process.py
@@ -11,15 +11,16 @@
 
 """Process handling helpers"""
 
-import subprocess
-import signal
 import os
+import signal
+import subprocess
 
 
 def getoutput(cmd):
     """Executes command and returns stdout+stderr without tailing \n\r"""
-    with subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE) as proc:
+    with subprocess.Popen(
+        cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    ) as proc:
         return proc.communicate()[0].decode().rstrip("\n\r")
 
 
@@ -84,7 +85,7 @@ def get_children_pids(ppid):
     param ppid: parent PID
     return: list of PIDs of all children/threads of ppid
     """
-    return getoutput(f"ps -L --ppid={int(ppid)} -o lwp").split('\n')[1:]
+    return getoutput(f"ps -L --ppid={int(ppid)} -o lwp").split("\n")[1:]
 
 
 def process_in_ptree_is_defunct(ppid):
@@ -104,7 +105,7 @@ def process_in_ptree_is_defunct(ppid):
     for pid in pids:
         cmd = f"ps --no-headers -o cmd {int(pid)}"
         proc_name = getoutput(cmd)
-        if '<defunct>' in proc_name:
+        if "<defunct>" in proc_name:
             defunct = True
             break
     return defunct

--- a/aexpect/utils/wait.py
+++ b/aexpect/utils/wait.py
@@ -11,8 +11,8 @@
 
 """Module that helps waiting for conditions"""
 
-import time
 import logging
+import time
 
 _LOG = logging.getLogger(__file__)
 

--- a/scripts/aexpect_helper
+++ b/scripts/aexpect_helper
@@ -15,21 +15,23 @@
 Helper script that runs and interacts with the process executed by aexpect
 """
 
-import os
-import sys
 import logging
+import os
 import pty
-import tempfile
 import select
+import sys
+import tempfile
 
-from aexpect.shared import BASE_DIR
-from aexpect.shared import get_filenames
-from aexpect.shared import get_reader_filename
-from aexpect.shared import get_lock_fd
-from aexpect.shared import unlock_fd
-from aexpect.shared import wait_for_lock
-from aexpect.shared import makestandard
-from aexpect.shared import makeraw
+from aexpect.shared import (
+    BASE_DIR,
+    get_filenames,
+    get_lock_fd,
+    get_reader_filename,
+    makeraw,
+    makestandard,
+    unlock_fd,
+    wait_for_lock,
+)
 
 
 def main():     # too-many-* pylint:disable=R0914,R0912,R0915

--- a/setup.py
+++ b/setup.py
@@ -17,22 +17,23 @@
 
 from setuptools import setup
 
-if __name__ == '__main__':
-    setup(name='aexpect',
-          version='1.7.0',
-          description='Aexpect',
-          author='Aexpect developers',
-          author_email='avocado-devel@redhat.com',
-          url='http://avocado-framework.github.io/',
-          license="GPLv2+",
-          classifiers=[
+if __name__ == "__main__":
+    setup(
+        name="aexpect",
+        version="1.7.0",
+        description="Aexpect",
+        author="Aexpect developers",
+        author_email="avocado-devel@redhat.com",
+        url="http://avocado-framework.github.io/",
+        license="GPLv2+",
+        classifiers=[
             "Development Status :: 6 - Mature",
             "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
             "Natural Language :: English",
             "Operating System :: POSIX",
             "Programming Language :: Python :: 3",
-              ],
-          packages=['aexpect',
-                    'aexpect.utils'],
-          scripts=['scripts/aexpect_helper'],
-          test_suite='tests')
+        ],
+        packages=["aexpect", "aexpect.utils"],
+        scripts=["scripts/aexpect_helper"],
+        test_suite="tests",
+    )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,13 +24,11 @@ from aexpect import client
 
 
 class ClientTest(unittest.TestCase):
-
     def test_client_spawn(self):
         """
         Tests the basic spawning of an interactive process
         """
-        key = "".join([random.choice(string.ascii_uppercase)
-                       for _ in range(10)])
+        key = "".join([random.choice(string.ascii_uppercase) for _ in range(10)])
         python = client.Spawn(sys.executable)
         self.assertTrue(python.is_alive())
         python.sendline(f"print('{key}')")
@@ -41,24 +39,37 @@ class ClientTest(unittest.TestCase):
 
 
 class CommandsTests(unittest.TestCase):
-
     def setUp(self):
-        non_get_cmds = ('get_id', 'get_output', 'get_pid', 'get_status',
-                        'get_stripped_output')
-        self.cmds = [cmd for cmd in dir(client.ShellSession)
-                     if cmd.startswith('get') and cmd not in non_get_cmds]
-        self.cmds.extend(cmd for cmd in dir(client.ShellSession)
-                         if cmd.startswith("cmd"))
+        non_get_cmds = (
+            "get_id",
+            "get_output",
+            "get_pid",
+            "get_status",
+            "get_stripped_output",
+        )
+        self.cmds = [
+            cmd
+            for cmd in dir(client.ShellSession)
+            if cmd.startswith("get") and cmd not in non_get_cmds
+        ]
+        self.cmds.extend(
+            cmd for cmd in dir(client.ShellSession) if cmd.startswith("cmd")
+        )
 
     def test_cmd_true(self):
         """Check that the true command finishes properly"""
         for cmd in self.cmds:
-            if cmd in ('get_id', 'get_output', 'get_pid', 'get_status',
-                       'get_stripped_output'):
+            if cmd in (
+                "get_id",
+                "get_output",
+                "get_pid",
+                "get_status",
+                "get_stripped_output",
+            ):
                 # These are not commands
                 continue
             session = client.ShellSession("sh")
-            getattr(session, cmd)('true')
+            getattr(session, cmd)("true")
 
     def test_cmd_terminated(self):
         """
@@ -66,8 +77,13 @@ class CommandsTests(unittest.TestCase):
         raised
         """
         for cmd in self.cmds:
-            if cmd in ('get_id', 'get_output', 'get_pid', 'get_status',
-                       'get_stripped_output'):
+            if cmd in (
+                "get_id",
+                "get_output",
+                "get_pid",
+                "get_status",
+                "get_stripped_output",
+            ):
                 # These are not commands
                 continue
             session = client.ShellSession("sh")
@@ -80,50 +96,62 @@ class CommandsTests(unittest.TestCase):
                 # command will be processed after the helper realizes
                 # it's dead.
                 out = getattr(session, cmd)(f"kill {session.get_pid()}")
-                out += getattr(session, cmd)('true')
-                self.fail("Killed session did not produce 'ShellError' using "
-                          f"command {cmd} ({self.cmds})\n{out}")
+                out += getattr(session, cmd)("true")
+                self.fail(
+                    "Killed session did not produce 'ShellError' using "
+                    f"command {cmd} ({self.cmds})\n{out}"
+                )
             except client.ShellError as details:
                 if cmd in ("cmd_output", "cmd_output_safe"):
-                    if not isinstance(details,
-                                      client.ShellProcessTerminatedError):
-                        self.fail(f"Incorrect exception '{details}' "
-                                  f"({type(details)}) was raised using command"
-                                  f" {cmd} ({self.cmds})\n{out}")
+                    if not isinstance(details, client.ShellProcessTerminatedError):
+                        self.fail(
+                            f"Incorrect exception '{details}' "
+                            f"({type(details)}) was raised using command"
+                            f" {cmd} ({self.cmds})\n{out}"
+                        )
 
     def test_cmd_timeout(self):
         """Check that 0s timeout timeouts"""
         for cmd in self.cmds:
-            if cmd in ('get_id', 'get_output', 'get_pid', 'get_status',
-                       'get_stripped_output'):
+            if cmd in (
+                "get_id",
+                "get_output",
+                "get_pid",
+                "get_status",
+                "get_stripped_output",
+            ):
                 # These are not commands
                 continue
             session = client.ShellSession("sh")
             try:
-                execute = (f"{sys.executable} -c "
-                           "'import time; time.sleep(10)'")
+                execute = f"{sys.executable} -c " "'import time; time.sleep(10)'"
                 out = getattr(session, cmd)(execute, timeout=0)
-                self.fail("Killed session did not produce 'ShellError' using "
-                          f"command {cmd} ({self.cmds})\n{out}")
+                self.fail(
+                    "Killed session did not produce 'ShellError' using "
+                    f"command {cmd} ({self.cmds})\n{out}"
+                )
             except client.ShellError as details:
                 if cmd in ("cmd_output", "cmd_output_safe"):
-                    if not isinstance(details,
-                                      client.ShellTimeoutError):
-                        self.fail(f"Incorrect exception '{details}' "
-                                  f"({type(details)}) was raised "
-                                  f"using command {cmd} ({self.cmds})")
+                    if not isinstance(details, client.ShellTimeoutError):
+                        self.fail(
+                            f"Incorrect exception '{details}' "
+                            f"({type(details)}) was raised "
+                            f"using command {cmd} ({self.cmds})"
+                        )
 
-    @unittest.skipUnless(os.environ.get('AEXPECT_TIME_SENSITIVE'),
-                         "AEXPECT_TIME_SENSITIVE env variable not set")
+    @unittest.skipUnless(
+        os.environ.get("AEXPECT_TIME_SENSITIVE"),
+        "AEXPECT_TIME_SENSITIVE env variable not set",
+    )
     def test_cmd_output_with_inner_timeout(self):
         """
         cmd_output_safe uses 0.5s inner timeout, make sure all lines are
         present in the output.
         """
         session = client.ShellSession("sh")
-        out = session.cmd_output_safe("echo FIRST LINE; sleep 2; "
-                                      "echo SECOND LINE; sleep 2; "
-                                      "echo THIRD LINE")
+        out = session.cmd_output_safe(
+            "echo FIRST LINE; sleep 2; echo SECOND LINE; sleep 2; echo THIRD LINE"
+        )
         self.assertIn("FIRST LINE", out)
         self.assertIn("SECOND LINE", out)
         self.assertIn("THIRD LINE", out)
@@ -132,6 +160,7 @@ class CommandsTests(unittest.TestCase):
         """
         Check file descriptors are not being leaked
         """
+
         def get_proc_fds():
             """
             Returns a set containing the fd names opened under the process
@@ -147,10 +176,12 @@ class CommandsTests(unittest.TestCase):
         session = client.ShellSession("sh")
         session.close()
         fds_after = get_proc_fds()
-        self.assertEqual(fds_after, fds_before,
-                         msg="fd leak: Closing the session didn't close "
-                             "the file descriptors")
+        self.assertEqual(
+            fds_after,
+            fds_before,
+            msg="fd leak: Closing the session didn't close " "the file descriptors",
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pass_fds.py
+++ b/tests/test_pass_fds.py
@@ -19,13 +19,11 @@ import unittest
 
 from aexpect import client
 
-LIST_FD_CMD = ('''python -c "import os; os.system('ls -l /proc/%d/fd' % '''
-               '''os.getpid())"''')
+LIST_FD_CMD = """python -c 'import os; os.system("ls -l /proc/%d/fd" % os.getpid())'"""
 
 
 class PassfdsTest(unittest.TestCase):
-
-    @unittest.skipUnless(os.path.exists('/proc/1/fd'), "requires Linux")
+    @unittest.skipUnless(os.path.exists("/proc/1/fd"), "requires Linux")
     def test_pass_fds_spawn(self):
         """
         Tests fd passing for `client.Spawn`
@@ -34,17 +32,15 @@ class PassfdsTest(unittest.TestCase):
             fd_null = devnull.fileno()
 
             child = client.Spawn(LIST_FD_CMD)
-            self.assertFalse(bool(child.get_status()),
-                             "child terminated abnormally")
+            self.assertFalse(bool(child.get_status()), "child terminated abnormally")
             self.assertNotIn(os.devnull, child.get_output())
             child.close()
 
             child = client.Spawn(LIST_FD_CMD, pass_fds=[fd_null])
-            self.assertFalse(bool(child.get_status()),
-                             "child terminated abnormally")
+            self.assertFalse(bool(child.get_status()), "child terminated abnormally")
             self.assertIn(os.devnull, child.get_output())
             child.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_remote_door.py
+++ b/tests/test_remote_door.py
@@ -14,8 +14,8 @@
 #
 # selftests pylint: disable=C0111,C0111,W0613,R0913
 
-import os
 import glob
+import os
 import re
 import shutil
 import unittest.mock
@@ -27,22 +27,46 @@ mock = unittest.mock
 
 
 # noinspection PyUnusedLocal
-def _local_login(client, host, port, username, password, prompt,
-                 linesep="\n", log_filename=None, log_function=None,
-                 timeout=10, internal_timeout=10, interface=None):
+def _local_login(
+    client,
+    host,
+    port,
+    username,
+    password,
+    prompt,
+    linesep="\n",
+    log_filename=None,
+    log_function=None,
+    timeout=10,
+    internal_timeout=10,
+    interface=None,
+):
     return RemoteSession("sh", prompt=prompt, client=client)
 
 
 # noinspection PyUnusedLocal
-def _local_copy(address, client, username, password, port, local_path,
-                remote_path, limit="", log_filename=None, log_function=None,
-                verbose=False, timeout=600, interface=None, filesize=None,
-                directory=True):
+def _local_copy(
+    address,
+    client,
+    username,
+    password,
+    port,
+    local_path,
+    remote_path,
+    limit="",
+    log_filename=None,
+    log_function=None,
+    verbose=False,
+    timeout=600,
+    interface=None,
+    filesize=None,
+    directory=True,
+):
     shutil.copy(local_path, remote_path)
 
 
-@mock.patch('aexpect.remote_door.remote.copy_files_to', _local_copy)
-@mock.patch('aexpect.remote_door.remote.wait_for_login', _local_login)
+@mock.patch("aexpect.remote_door.remote.copy_files_to", _local_copy)
+@mock.patch("aexpect.remote_door.remote.wait_for_login", _local_login)
 class RemoteDoorTest(unittest.TestCase):
     """Unit test class for the remote door."""
 
@@ -54,10 +78,13 @@ class RemoteDoorTest(unittest.TestCase):
     def tearDown(self):
         for control_file in glob.glob("tmp*.control"):
             os.unlink(control_file)
-        for control_file in glob.glob(os.path.join(remote_door.REMOTE_CONTROL_DIR,
-                                                   "tmp*.control")):
+        for control_file in glob.glob(
+            os.path.join(remote_door.REMOTE_CONTROL_DIR, "tmp*.control")
+        ):
             os.unlink(control_file)
-        deployed_remote_door = os.path.join(remote_door.REMOTE_PYTHON_PATH, "remote_door.py")
+        deployed_remote_door = os.path.join(
+            remote_door.REMOTE_PYTHON_PATH, "remote_door.py"
+        )
         if os.path.exists(deployed_remote_door):
             os.unlink(deployed_remote_door)
         os.rmdir(remote_door.REMOTE_PYTHON_PATH)
@@ -68,12 +95,14 @@ class RemoteDoorTest(unittest.TestCase):
         result = remote_door.run_remote_util(self.session, "math", "gcd", 2, 3)
         self.assertEqual(int(result), 1)
         local_controls = glob.glob("tmp*.control")
-        remote_controls = glob.glob(os.path.join(remote_door.REMOTE_CONTROL_DIR,
-                                                 "tmp*.control"))
+        remote_controls = glob.glob(
+            os.path.join(remote_door.REMOTE_CONTROL_DIR, "tmp*.control")
+        )
         self.assertEqual(len(local_controls), len(remote_controls))
         self.assertEqual(len(remote_controls), 1)
-        self.assertEqual(os.path.basename(local_controls[0]),
-                         os.path.basename(remote_controls[0]))
+        self.assertEqual(
+            os.path.basename(local_controls[0]), os.path.basename(remote_controls[0])
+        )
         with open(remote_controls[0], encoding="utf-8") as handle:
             control_lines = handle.readlines()
         self.assertIn("import math\n", control_lines)
@@ -81,43 +110,56 @@ class RemoteDoorTest(unittest.TestCase):
 
     def test_run_remote_util_arg_types(self):
         """Test that a remote utility runs properly with different argument types."""
-        result = remote_door.run_remote_util(self.session, "json", "dumps",
-                                             ["foo", {"bar": ["baz", None, 1.0, 2]}],
-                                             skipkeys=False, separators=None,
-                                             # must be boolean but we want to test string
-                                             allow_nan="string for yes")
+        result = remote_door.run_remote_util(
+            self.session,
+            "json",
+            "dumps",
+            ["foo", {"bar": ["baz", None, 1.0, 2]}],
+            skipkeys=False,
+            separators=None,
+            # must be boolean but we want to test string
+            allow_nan="string for yes",
+        )
         self.assertEqual(result, '["foo", {"bar": ["baz", null, 1.0, 2]}]')
         local_controls = glob.glob("tmp*.control")
-        remote_controls = glob.glob(os.path.join(remote_door.REMOTE_CONTROL_DIR,
-                                                 "tmp*.control"))
+        remote_controls = glob.glob(
+            os.path.join(remote_door.REMOTE_CONTROL_DIR, "tmp*.control")
+        )
         self.assertEqual(len(local_controls), len(remote_controls))
         self.assertEqual(len(remote_controls), 1)
-        self.assertEqual(os.path.basename(local_controls[0]),
-                         os.path.basename(remote_controls[0]))
+        self.assertEqual(
+            os.path.basename(local_controls[0]), os.path.basename(remote_controls[0])
+        )
         with open(remote_controls[0], encoding="utf-8") as handle:
             control_lines = handle.readlines()
         self.assertIn("import json\n", control_lines)
-        self.assertIn("result = json.dumps(['foo', {'bar': ['baz', None, 1.0, 2]}], "
-                      "allow_nan=r'string for yes', separators=None, skipkeys=False)\n",
-                      control_lines)
+        self.assertIn(
+            "result = json.dumps(['foo', {'bar': ['baz', None, 1.0, 2]}], "
+            "allow_nan=r'string for yes', separators=None, skipkeys=False)\n",
+            control_lines,
+        )
 
     def test_run_remote_util_object(self):
         """Test that a remote utility object runs properly."""
-        result = remote_door.run_remote_util(self.session, "collections",
-                                             "OrderedDict().get", "akey")
+        result = remote_door.run_remote_util(
+            self.session, "collections", "OrderedDict().get", "akey"
+        )
         self.assertEqual(result, "None")
 
         local_controls = glob.glob("tmp*.control")
-        remote_controls = glob.glob(os.path.join(remote_door.REMOTE_CONTROL_DIR,
-                                                 "tmp*.control"))
+        remote_controls = glob.glob(
+            os.path.join(remote_door.REMOTE_CONTROL_DIR, "tmp*.control")
+        )
         self.assertEqual(len(local_controls), len(remote_controls))
         self.assertEqual(len(remote_controls), 1)
-        self.assertEqual(os.path.basename(local_controls[0]),
-                         os.path.basename(remote_controls[0]))
+        self.assertEqual(
+            os.path.basename(local_controls[0]), os.path.basename(remote_controls[0])
+        )
         with open(remote_controls[0], encoding="utf-8") as handle:
             control_lines = handle.readlines()
-        self.assertIn("result = collections.OrderedDict().get(r'akey')\n",
-                      control_lines)
+        self.assertIn(
+            "result = collections.OrderedDict().get(r'akey')\n", control_lines
+        )
 
     def test_run_remote_decorator(self):
         """Test that a remote decorated function runs properly."""
@@ -137,12 +179,14 @@ class RemoteDoorTest(unittest.TestCase):
         self.assertEqual(int(result), 4)
 
         local_controls = glob.glob("tmp*.control")
-        remote_controls = glob.glob(os.path.join(remote_door.REMOTE_CONTROL_DIR,
-                                                 "tmp*.control"))
+        remote_controls = glob.glob(
+            os.path.join(remote_door.REMOTE_CONTROL_DIR, "tmp*.control")
+        )
         self.assertEqual(len(local_controls), len(remote_controls))
         self.assertEqual(len(remote_controls), 1)
-        self.assertEqual(os.path.basename(local_controls[0]),
-                         os.path.basename(remote_controls[0]))
+        self.assertEqual(
+            os.path.basename(local_controls[0]), os.path.basename(remote_controls[0])
+        )
         with open(remote_controls[0], encoding="utf-8") as handle:
             control_lines = handle.readlines()
         self.assertIn("def add_one(number):\n", control_lines)
@@ -150,11 +194,14 @@ class RemoteDoorTest(unittest.TestCase):
 
     def test_get_remote_object(self):
         """Test that a remote object can be retrieved properly."""
-        self.session = mock.MagicMock(name='session')
+        self.session = mock.MagicMock(name="session")
         self.session.client = "ssh"
         remote_door.Pyro4 = mock.MagicMock()
         disconnect = remote_door.Pyro4.errors.PyroError = Exception
-        remote_door.Pyro4.Proxy.side_effect = [disconnect("no such object"), mock.DEFAULT]
+        remote_door.Pyro4.Proxy.side_effect = [
+            disconnect("no such object"),
+            mock.DEFAULT,
+        ]
         self.session.get_output.return_value = "Local object sharing ready\n"
         self.session.get_output.return_value += "RESULT = None\n"
 
@@ -169,37 +216,42 @@ class RemoteDoorTest(unittest.TestCase):
         self.assertIsNotNone(match, "A control file has to be called on the peer side")
         control_file = match.group(1)
         local_controls = glob.glob("tmp*.control")
-        remote_controls = glob.glob(os.path.join(remote_door.REMOTE_CONTROL_DIR,
-                                                 "tmp*.control"))
+        remote_controls = glob.glob(
+            os.path.join(remote_door.REMOTE_CONTROL_DIR, "tmp*.control")
+        )
         self.assertEqual(len(local_controls), len(remote_controls))
         self.assertEqual(len(remote_controls), 1)
-        self.assertEqual(os.path.basename(local_controls[0]),
-                         os.path.basename(remote_controls[0]))
+        self.assertEqual(
+            os.path.basename(local_controls[0]), os.path.basename(remote_controls[0])
+        )
         self.assertEqual(control_file, os.path.basename(remote_controls[0]))
         with open(control_file, encoding="utf-8") as handle:
             control_lines = handle.readlines()
             self.assertIn("import remote_door\n", control_lines)
-            self.assertIn("result = remote_door.share_local_object(r'html', "
-                          "host=r'testhost', port=4242)\n",
-                          control_lines)
+            self.assertIn(
+                "result = remote_door.share_local_object(r'html', "
+                "host=r'testhost', port=4242)\n",
+                control_lines,
+            )
 
         # since the local run was face redo it here
         remote_door.share_local_object("html", None, "testhost", 4242)
 
     def test_share_remote_objects(self):
         """Test that a remote object can be shared properly and remotely."""
-        self.session = mock.MagicMock(name='session')
+        self.session = mock.MagicMock(name="session")
         self.session.client = "ssh"
         remote_door.Pyro4 = mock.MagicMock()
 
-        control_file = os.path.join(remote_door.REMOTE_CONTROL_DIR,
-                                    "tmpxxxxxxxx.control")
+        control_file = os.path.join(
+            remote_door.REMOTE_CONTROL_DIR, "tmpxxxxxxxx.control"
+        )
         with open(control_file, "wt", encoding="utf-8") as handle:
             handle.write("print('Remote objects shared over the network')")
 
-        middleware = remote_door.share_remote_objects(self.session, control_file,
-                                                      "testhost", 4242,
-                                                      os_type="linux")
+        middleware = remote_door.share_remote_objects(
+            self.session, control_file, "testhost", 4242, os_type="linux"
+        )
         # we just test dummy initialization for the remote object control server
         middleware.close()
 
@@ -213,9 +265,11 @@ class RemoteDoorTest(unittest.TestCase):
     def test_import_remote_exceptions(self):
         """Test that selected remote exceptions are properly imported and deserialized."""
         remote_door.Pyro4 = mock.MagicMock()
-        preselected_exceptions = ["aexpect.remote.RemoteError",
-                                  "aexpect.remote.LoginError",
-                                  "aexpect.remote.TransferError"]
+        preselected_exceptions = [
+            "aexpect.remote.RemoteError",
+            "aexpect.remote.LoginError",
+            "aexpect.remote.TransferError",
+        ]
         remote_door.import_remote_exceptions(preselected_exceptions)
         register_method = remote_door.Pyro4.util.SerializerBase.register_dict_to_class
         self.assertEqual(len(register_method.mock_calls), 3)


### PR DESCRIPTION
Adds a Python module import order check, and code style check.

This is based on "avocado-static-checks", which is being added here as a submodule.  On CI, it uses the "avocado-ci-tools" actions to check out and run it, but the same can be done locally with the submodule.