### PR TITLE
utils/astring: add expected control characters

### DIFF
--- a/aexpect/utils/astring.py
+++ b/aexpect/utils/astring.py
@@ -37,6 +37,7 @@ def strip_console_codes(output, custom_codes=None):
     output = f"\x1b[m{output}"
     console_codes = "%[G@8]|\\[[@A-HJ-MPXa-hl-nqrsu\\`]"
     console_codes += "|\\[[\\d;]+[HJKgqnrm]|#8|\\([B0UK]|\\)|\\[\\?2004[lh]"
+    console_codes += "|[c]|[!p]|[\\]104]"
     if custom_codes is not None and custom_codes not in console_codes:
         console_codes += f"|{custom_codes}"
     while index < len(output):


### PR DESCRIPTION
Fixes: #133

In recent kernel boots, stripping raised error because of missing control characters.

Add them:
`c` reset screen
`!p` soft reset terminal
`]104` - execute OS command '104'

These control characters are listed in the xterm control sequence cheat
sheet at
https://gist.github.com/justinmk/a5102f9a0c1810437885a04a07ef0a91