### PR TITLE
utils.astring: A couple of strip_console_codes fixes

### DIFF
--- a/aexpect/utils/astring.py
+++ b/aexpect/utils/astring.py
@@ -54,7 +54,7 @@ def strip_console_codes(output, custom_codes=None):
         try:
             special_code = re.findall(console_codes, tmp_word)[0]
         except IndexError as error:
-            if index + tmp_index < len(output):
+            if index < len(output):
                 raise ValueError(f"{tmp_word} is not included in the known "
                                  "console codes list "
                                  f"{console_codes}") from error

--- a/aexpect/utils/astring.py
+++ b/aexpect/utils/astring.py
@@ -35,8 +35,9 @@ def strip_console_codes(output, custom_codes=None):
     return_str = ""
     index = 0
     output = f"\x1b[m{output}"
-    console_codes = "%[G@8]|\\[[@A-HJ-MPXa-hl-nqrsu\\`]"
-    console_codes += "|\\[[\\d;]+[HJKgqnrm]|#8|\\([B0UK]|\\)|\\[\\?2004[lh]"
+    console_codes = "^%[G@8]|^\\[[@A-HJ-MPXa-hl-nqrsu\\`]"
+    console_codes += "|^\\[[\\d;]+[HJKgqnrm]|^#8|^\\([B0UK]|^\\)"
+    console_codes += "|^\\[\\?2004[lh]"
     if custom_codes is not None and custom_codes not in console_codes:
         console_codes += f"|{custom_codes}"
     while index < len(output):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,36 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: Red Hat Inc. 2024
+# Author: Lukas Doktor <ldoktor@redhat.com>
+
+# selftests pylint: disable=C0111,C0111
+
+import unittest
+
+from aexpect.utils import astring
+
+
+class Astring(unittest.TestCase):
+
+    def test_strip_console_codes(self):
+        """
+        Try various strip_console_codes
+        """
+        strip = astring.strip_console_codes
+        self.assertEqual("simple color test",
+                         strip("simple\x1b[33;1m color \x1b[0mtest"))
+        self.assertEqual("[33;1mstarts with code", "[33;1mstarts with code")
+        self.assertEqual("ends with escape\x1b", "ends with escape\x1b")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,6 +34,9 @@ class Astring(unittest.TestCase):
                          strip("ignores last\x1bbad"))
         self.assertRaisesRegex(ValueError, "only is not included", strip,
                                "ignores\x1bonly\x1blast\x1bbad")
+        self.assertRaisesRegex(ValueError, "invalid-prefix.*included", strip,
+                               "\x1binvalid-prefix[33;1mconsole code "
+                               "must fail\x1b")
 
 
 if __name__ == '__main__':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,8 +28,12 @@ class Astring(unittest.TestCase):
         strip = astring.strip_console_codes
         self.assertEqual("simple color test",
                          strip("simple\x1b[33;1m color \x1b[0mtest"))
-        self.assertEqual("[33;1mstarts with code", "[33;1mstarts with code")
-        self.assertEqual("ends with escape\x1b", "ends with escape\x1b")
+        self.assertEqual("",
+                         strip("\x1bskip-full-text"))
+        self.assertEqual("ignores last",
+                         strip("ignores last\x1bbad"))
+        self.assertRaisesRegex(ValueError, "only is not included", strip,
+                               "ignores\x1bonly\x1blast\x1bbad")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I noticed the strip_console_code works quite oddly, let's add a selftest and fix the biggest issues.