### PR TITLE
Makefile: Skip newly added R0917

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ rpm-release: srpm-release
 	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/python-aexpect-$(VERSION)-*.src.rpm
 
 check: clean
-	inspekt checkall --disable-lint R0205,W4901,W0703,W0511 --exclude .venv*
+	inspekt checkall --disable-lint R0917,R0205,W4901,W0703,W0511 --exclude .venv*
 	$(PYTHON) setup.py develop $(PYTHON_DEVELOP_ARGS)
 	$(PYTHON) setup.py test
 


### PR DESCRIPTION
disable too-many-positional-arguments (R0917) in our CI as we don't intend to refactor the code to use named arguments instead.