### PR TITLE
Provide remote Pyro5 compatibility for multiple remote objects

### DIFF
--- a/aexpect/remote_door.py
+++ b/aexpect/remote_door.py
@@ -77,6 +77,7 @@ try:
         from Pyro5 import server
         # noinspection PyPackageRequirements
         from Pyro5 import nameserver
+        NS_MODULE = "Pyro5.nameserver"
     except ImportError:
         # noinspection PyPackageRequirements,PyUnresolvedReferences
         import Pyro4
@@ -92,10 +93,12 @@ try:
         # noinspection PyPackageRequirements
         from Pyro4 import naming as nameserver
         nameserver.start_ns = nameserver.startNS
+        NS_MODULE = "Pyro4.naming"
 
 except ImportError:
     logging.warning("Remote object backend (Pyro4) not found, some functionality"
                     " of the remote door will not be available")
+    NS_MODULE = ""
 
 # NOTE: disable aexpect importing on the remote side if not available as the
 # remote door can run code remotely without the requirement for the aexpect
@@ -848,7 +851,7 @@ def share_remote_objects(session, control_path, host="localhost", port=9090,
 
     # setup remote objects server
     LOG.info("Starting nameserver for the remote objects")
-    cmd = f"python -m Pyro4.naming -n {host} -p {port}"
+    cmd = f"python -m {NS_MODULE} -n {host} -p {port}"
     session.cmd("START " + cmd if os_type == "windows" else cmd + " &")
 
     LOG.info("Starting the server daemon for the remote objects")

--- a/tests/test_remote_door.py
+++ b/tests/test_remote_door.py
@@ -217,6 +217,7 @@ class RemoteDoorTest(unittest.TestCase):
         """Test that a remote object can be shared properly and remotely."""
         self.session = mock.MagicMock(name='session')
         self.session.client = "ssh"
+        remote_door.NS_MODULE = "pyro.name.server"
 
         control_file = os.path.join(remote_door.REMOTE_CONTROL_DIR,
                                     "tmpxxxxxxxx.control")
@@ -234,7 +235,7 @@ class RemoteDoorTest(unittest.TestCase):
         else:
             self.assertEqual(self.session.cmd.call_count, 1)
         command = self.session.cmd.call_args[0][0]
-        self.assertEqual("python -m Pyro4.naming -n testhost -p 4242 &", command)
+        self.assertEqual(f"python -m {remote_door.NS_MODULE} -n testhost -p 4242 &", command)
 
     def test_import_remote_exceptions(self):
         """Test that selected remote exceptions are properly imported and deserialized."""


### PR DESCRIPTION
This is a more rarely used case that we could cover with Pyro5 support as well. The advertised method remains in retrieving multiple remote objects one by one using single remote object getter and this one remains more manual and requiring of control file implementation.