### PR TITLE
Removing the escape sequence from the console output!

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -1311,11 +1311,8 @@ class ShellSession(Expect):
             # Send the 'echo $?' (or equivalent) command to get the exit status
             status = self.cmd_output(self.status_test_command, 30,
                                      internal_timeout, print_func, safe)
-            # Escape sequence for Bracketed Paste Mode
-            escape_sequence = r'\x1b\[\?[0-9;]*[hl]'
-
-            # Remove the Bracketed Paste Mode escape sequence using re.sub
-            clean_status = re.sub(escape_sequence, '', status)
+            # Using the function to remove escape sequence from the output
+            clean_status = astring.strip_console_codes(status)
         except ShellError as error:
             raise ShellStatusError(cmd, out) from error
 

--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -1311,11 +1311,16 @@ class ShellSession(Expect):
             # Send the 'echo $?' (or equivalent) command to get the exit status
             status = self.cmd_output(self.status_test_command, 30,
                                      internal_timeout, print_func, safe)
+            # Escape sequence for Bracketed Paste Mode
+            escape_sequence = r'\x1b\[\?[0-9;]*[hl]'
+
+            # Remove the Bracketed Paste Mode escape sequence using re.sub
+            clean_status = re.sub(escape_sequence, '', status)
         except ShellError as error:
             raise ShellStatusError(cmd, out) from error
 
         # Get the first line consisting of digits only
-        digit_lines = [_ for _ in status.splitlines()
+        digit_lines = [_ for _ in clean_status.splitlines()
                        if self.__RE_STATUS.match(_.strip())]
         if digit_lines:
             return int(digit_lines[0].strip()), out


### PR DESCRIPTION
The output coming from the console Terminal consists of Bracketed Paste escape sequence! I have updated the code in a way that it will check the status output and see if the output has this sequence, it will remove this from the output and then use only integer o/p of status command!

Before applying the patch status output was:
^[[?2004l0

After applying the patch status output is:
0
Signed-off-by: Anushree Mathur [anushree.mathur@linux.vnet.ibm.com](mailto:anushree.mathur@linux.vnet.ibm.com)