### PR TITLE
Failed kill

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -434,7 +434,13 @@ class Spawn:
         if not self.closed:
             self.kill(sig=sig)
             # Wait for the server to exit
-            wait_for_lock(self.lock_server_running_filename)
+            if not wait_for_lock(
+                self.lock_server_running_filename, timeout=60
+            ):
+                LOG.warning(
+                    "Failed to get lock, the aexpect_helper process "
+                    "might be left behind. Proceeding anyway..."
+                )
             # Call all cleanup routines
             for hook in self.close_hooks:
                 hook(self)

--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -266,8 +266,8 @@ class Spawn:
         # Wait for the server to complete its initialization
         full_output = ""
         pattern = f"Server {self.a_id} ready"
-        end_time = time.time() + 60
-        while time.time() < end_time:
+        end_time = time.monotonic() + 60
+        while time.monotonic() < end_time:
             output = sub.stdout.readline().decode(self.encoding, "ignore")
             if pattern in output:
                 break
@@ -896,7 +896,7 @@ class Expect(Tail):
             internal_timeout *= 1000
         end_time = None
         if timeout:
-            end_time = time.time() + timeout
+            end_time = time.monotonic() + timeout
         expect_pipe = self._get_fd("expect")
         poller = select.poll()
         poller.register(expect_pipe, select.POLLIN)
@@ -915,7 +915,7 @@ class Expect(Tail):
                 data += raw_data.decode(self.encoding, "ignore")
             else:
                 return read, data
-            if end_time and time.time() > end_time:
+            if end_time and time.monotonic() > end_time:
                 return read, data
 
     def read_nonblocking(self, internal_timeout=None, timeout=None):
@@ -1009,10 +1009,10 @@ class Expect(Tail):
         poller = select.poll()
         poller.register(expect_pipe, select.POLLIN)
         output = ""
-        end_time = time.time() + timeout
+        end_time = time.monotonic() + timeout
         while True:
             try:
-                max_ms = int((end_time - time.time()) * 1000)
+                max_ms = int((end_time - time.monotonic()) * 1000)
                 poll_timeout_ms = max(0, max_ms)
                 poll_status = poller.poll(poll_timeout_ms)
             except select.error:
@@ -1021,7 +1021,7 @@ class Expect(Tail):
                 raise ExpectTimeoutError(patterns, output)
             # Read data from child
             read, data = self._read_nonblocking(
-                internal_timeout, end_time - time.time()
+                internal_timeout, end_time - time.monotonic()
             )
             if not read:
                 break
@@ -1291,10 +1291,10 @@ class ShellSession(Expect):
         # Send a newline
         self.sendline()
         # Wait up to timeout seconds for some output from the child
-        end_time = time.time() + timeout
-        while time.time() < end_time:
+        end_time = time.monotonic() + timeout
+        while time.monotonic() < end_time:
             time.sleep(0.5)
-            if self.read_nonblocking(0, end_time - time.time()).strip():
+            if self.read_nonblocking(0, end_time - time.monotonic()).strip():
                 return True
         # No output -- report unresponsive
         return False
@@ -1414,8 +1414,8 @@ class ShellSession(Expect):
         self.sendline(cmd)
         out = ""
         success = False
-        start_time = time.time()
-        while (time.time() - start_time) < timeout:
+        start_time = time.monotonic()
+        while (time.monotonic() - start_time) < timeout:
             try:
                 out += self.read_up_to_prompt(0.5)
                 success = True
@@ -1751,8 +1751,8 @@ def run_tail(
         encoding=encoding,
     )
 
-    end_time = time.time() + timeout
-    while time.time() < end_time and bg_process.is_alive():
+    end_time = time.monotonic() + timeout
+    while time.monotonic() < end_time and bg_process.is_alive():
         time.sleep(0.1)
 
     return bg_process
@@ -1804,8 +1804,8 @@ def run_bg(
         encoding=encoding,
     )
 
-    end_time = time.time() + timeout
-    while time.time() < end_time and bg_process.is_alive():
+    end_time = time.monotonic() + timeout
+    while time.monotonic() < end_time and bg_process.is_alive():
         time.sleep(0.1)
 
     return bg_process

--- a/aexpect/remote.py
+++ b/aexpect/remote.py
@@ -532,9 +532,9 @@ def wait_for_login(
         client,
         timeout,
     )
-    end_time = time.time() + timeout
+    end_time = time.monotonic() + timeout
     verbose = False
-    while time.time() < end_time:
+    while time.monotonic() < end_time:
         try:
             return remote_login(
                 client,
@@ -1375,9 +1375,9 @@ def throughput_transfer(func):
             msg = f"Copy file from {args[0]}:{args[5]} to {args[6]}, "
         else:
             msg = f"Copy file from {args[5]} to {args[0]}:{args[6]}, "
-        start_time = time.time()
+        start_time = time.monotonic()
         ret = func(*args, **kwargs)
-        elapsed_time = time.time() - start_time
+        elapsed_time = time.monotonic() - start_time
         if kwargs.get("filesize", None) is not None:
             throughput = kwargs["filesize"] / elapsed_time
             msg += f"estimated throughput: {throughput:.2f} MB/s"

--- a/aexpect/shared.py
+++ b/aexpect/shared.py
@@ -32,7 +32,7 @@ def get_lock_fd(filename, timeout=-1):
     end_time = time.time() + timeout if timeout > 0 else -1
     while True:
         try:
-            fcntl.lockf(lock_fd, lock_flags)
+            fcntl.flock(lock_fd, lock_flags)
             break
         except IOError:
             if time.time() > end_time:
@@ -43,7 +43,7 @@ def get_lock_fd(filename, timeout=-1):
 
 def unlock_fd(lock_fd):
     """Unlock a file"""
-    fcntl.lockf(lock_fd, fcntl.LOCK_UN)
+    fcntl.flock(lock_fd, fcntl.LOCK_UN)
     os.close(lock_fd)
 
 
@@ -54,11 +54,11 @@ def is_file_locked(filename):
     except OSError:
         return False
     try:
-        fcntl.lockf(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except IOError:
         os.close(lock_fd)
         return True
-    fcntl.lockf(lock_fd, fcntl.LOCK_UN)
+    fcntl.flock(lock_fd, fcntl.LOCK_UN)
     os.close(lock_fd)
     return False
 

--- a/aexpect/shared.py
+++ b/aexpect/shared.py
@@ -14,17 +14,30 @@
 import os
 import fcntl
 import termios
+import time
 
 BASE_DIR = os.environ.get("TMPDIR", "/tmp")
 
 
-def get_lock_fd(filename):
+def get_lock_fd(filename, timeout=-1):
     """Lock a file"""
     if not os.path.exists(filename):
         with open(filename, "w", encoding="utf-8"):
             pass
+
     lock_fd = os.open(filename, os.O_RDWR)
-    fcntl.lockf(lock_fd, fcntl.LOCK_EX)
+    lock_flags = fcntl.LOCK_EX
+    if timeout > 0:
+        lock_flags |= fcntl.LOCK_NB
+    end_time = time.time() + timeout if timeout > 0 else -1
+    while True:
+        try:
+            fcntl.lockf(lock_fd, lock_flags)
+            break
+        except IOError:
+            if time.time() > end_time:
+                os.close(lock_fd)
+                raise
     return lock_fd
 
 
@@ -50,10 +63,18 @@ def is_file_locked(filename):
     return False
 
 
-def wait_for_lock(filename):
-    """Wait until lock can be acquired, then release it"""
-    lock_fd = get_lock_fd(filename)
+def wait_for_lock(filename, timeout=-1):
+    """
+    Wait until lock can be acquired, then release it
+
+    :return: True on success, False on failure/timeout
+    """
+    try:
+        lock_fd = get_lock_fd(filename, timeout)
+    except (IOError, FileNotFoundError):
+        return False
     unlock_fd(lock_fd)
+    return True
 
 
 def makeraw(shell_fd):

--- a/aexpect/shared.py
+++ b/aexpect/shared.py
@@ -29,13 +29,13 @@ def get_lock_fd(filename, timeout=-1):
     lock_flags = fcntl.LOCK_EX
     if timeout > 0:
         lock_flags |= fcntl.LOCK_NB
-    end_time = time.time() + timeout if timeout > 0 else -1
+    end_time = time.monotonic() + timeout if timeout > 0 else -1
     while True:
         try:
             fcntl.flock(lock_fd, lock_flags)
             break
         except IOError:
-            if time.time() > end_time:
+            if time.monotonic() > end_time:
                 os.close(lock_fd)
                 raise
     return lock_fd

--- a/aexpect/utils/wait.py
+++ b/aexpect/utils/wait.py
@@ -30,14 +30,14 @@ def wait_for(func, timeout, first=0.0, step=1.0, text=None):
     :param step: Time to sleep between attempts in seconds
     :param text: Text to print while waiting, for debug purposes
     """
-    start_time = time.time()
-    end_time = time.time() + timeout
+    start_time = time.monotonic()
+    end_time = time.monotonic() + timeout
 
     time.sleep(first)
 
-    while time.time() < end_time:
+    while time.monotonic() < end_time:
         if text:
-            _LOG.debug("%s (%f secs)", text, (time.time() - start_time))
+            _LOG.debug("%s (%f secs)", text, (time.monotonic() - start_time))
 
         output = func()
         if output:


### PR DESCRIPTION
@smitterl identified a bug in aexpect, when unkillable `aexpect_worker` results in indefinite hang of `Spawn.close()`. To mitigate that I added a timeout to our `wait_for_lock` and used it in `close()` (this fix can be tested by commenting-out the `kill`). Then I noticed the `close()` can actually be called multiple times when the user uses multiple processes/threads. To address that I'd suggest moving to BSD flock rather than posix lockf as that one protects individual threads and adding another `close` lock file to protect this critical path. This can be tested by:

```
import aexpect
import threading
#import pydevd

def close_session(session):
    """Closes the given session."""
    #pydevd.settrace("127.0.0.1")
    session.close()

# Assuming you have a list of sessions to be closed
session = aexpect.ShellSession("bash")

threads = []
for _ in range(20000):
    thread = threading.Thread(target=close_session, args=(session,))
    threads.append(thread)

for thread in threads:
    thread.start()

for t in threads:
    t.join()

del(session)

print("DONE")
```

One thing I'm not completely sure about is whether we don't rely on the non-thread-safe lockf in aexpect so please test this thoroughly.