### PR TITLE
client: Avoid double-cleanup exception

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -473,7 +473,7 @@ class Spawn:
                 try:
                     unlock_fd(lock)
                     os.unlink(self._close_lockfile)
-                except FileNotFoundError:
+                except (FileNotFoundError, OSError):
                     # File already removed by other thread
                     pass
 


### PR DESCRIPTION
in python <3.13 it raises FileNotFoundError, but python 3.13 seems to raise OSError exception instead when trying to unlock non-existing file.

Fixes: https://github.com/avocado-framework/aexpect/pull/147#issuecomment-2970833737