### PR TITLE
Emit a helpful logging message on reused object server

### DIFF
--- a/aexpect/remote_door.py
+++ b/aexpect/remote_door.py
@@ -626,6 +626,7 @@ def get_remote_object(
         remote_object = Pyro4.Proxy(f"PYRONAME:{object_name}@{host}:{port}")
         # noinspection PyProtectedMember
         remote_object._pyroBind()
+        LOG.warning("Previous remote object server running, reusing it as is")
     except Pyro4.errors.PyroError as error:
         if not session:
             raise


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced logging to explicitly note when an existing remote object server connection is reused after binding. Improves diagnostics and operational visibility for troubleshooting and monitoring. This change is purely informational and does not alter behavior or control flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->