### PR TITLE
Disable pseudo-terminal allocation for the rsync copy backend

### DIFF
--- a/aexpect/remote.py
+++ b/aexpect/remote.py
@@ -667,7 +667,7 @@ def remote_copy(
     Transfer files using rsync or SCP, given a command line.
 
     :param command: The command to execute
-        (e.g. "rsync -avz -e 'ssh -p 22' /local/path user@host:/remote/path"
+        (e.g. "rsync -avz -e 'ssh -Tp 22' /local/path user@host:/remote/path"
         or "scp -r foobar root@localhost:/tmp/").
     :param password_list: Password list to send in reply to a password prompt.
     :param log_filename: If specified, log all output to this file
@@ -935,7 +935,7 @@ def rsync_to_remote(
     if directory:
         command += " -r"
     command += (
-        f" -avz -e 'ssh -p {port} -o UserKnownHostsFile=/dev/null "
+        f" -avz -e 'ssh -Tp {port} -o UserKnownHostsFile=/dev/null "
         f"-o StrictHostKeyChecking=no' {limit} "
         f"{quote_path(local_path)} {username}@{host}:{shlex.quote(remote_path)}"
     )
@@ -992,7 +992,7 @@ def rsync_from_remote(
     if directory:
         command += " -r"
     command += (
-        f" -avz -e 'ssh -p {port} -o UserKnownHostsFile=/dev/null "
+        f" -avz -e 'ssh -Tp {port} -o UserKnownHostsFile=/dev/null "
         f"-o StrictHostKeyChecking=no' {limit} "
         f"{username}@{host}:{quote_path(remote_path)} {shlex.quote(local_path)}"
     )

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -95,7 +95,7 @@ class TestRemoteFunctions(unittest.TestCase):
         )
         self.assertEqual(
             mock_remote_copy.call_args[0][0].command,
-            r"rsync -r -avz -e 'ssh -p 22 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'  /local/path user@127.0.0.1:/remote/path",
+            r"rsync -r -avz -e 'ssh -Tp 22 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'  /local/path user@127.0.0.1:/remote/path",
         )
 
     @mock.patch("aexpect.remote._remote_copy")
@@ -129,5 +129,5 @@ class TestRemoteFunctions(unittest.TestCase):
         )
         self.assertEqual(
             mock_remote_copy.call_args[0][0].command,
-            r"rsync -r -avz -e 'ssh -p 22 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'  user@127.0.0.1:/remote/path /local/path",
+            r"rsync -r -avz -e 'ssh -Tp 22 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'  user@127.0.0.1:/remote/path /local/path",
         )


### PR DESCRIPTION
In cases of hanging aexpect processes it is possible that we exhaust the pseudo-terminals on the system. Disabling pseudo-terminal allocation for the rsync backend should help mitigate this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SSH configuration in remote file synchronization operations.

* **Documentation**
  * Revised remote file transfer examples to reflect current practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->