### PR TITLE
Fix "make rpm"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PYTHON=$(shell which python 2>/dev/null || which python3 2>/dev/null)
 PROJECT=aexpect
-VERSION=$(shell $(PYTHON) -m setuptools_scm)
+VERSION=$(shell $(PYTHON) -m setuptools_scm 2>/dev/null || grep '^Version:' python-$(PROJECT).spec | awk '{print $$2}')
+SPEC_VERSION=$(shell grep '^Version:' python-$(PROJECT).spec | awk '{print $$2}')
 COMMIT=$(shell git log --pretty=format:'%H' -n 1)
 SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1)
 COMMIT_DATE=$(shell git log --pretty='format:%cd' --date='format:%Y%m%d' -n 1)
@@ -25,7 +26,7 @@ source: clean
 
 source-release: clean
 	mkdir -p SOURCES
-	git archive --prefix="$(PROJECT)-$(VERSION)/" -o "SOURCES/$(PROJECT)-$(VERSION).tar.gz" $(VERSION)
+	git archive --prefix="$(PROJECT)-$(SPEC_VERSION)/" -o "SOURCES/$(PROJECT)-$(SPEC_VERSION).tar.gz" $(SPEC_VERSION)
 
 install:
 	rm -r dist 2>/dev/null || true
@@ -74,7 +75,7 @@ srpm: source
 
 rpm: srpm
 	mkdir -p BUILD/RPM
-	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --rebuild BUILD/SRPM/python-$(PROJECT)-$(VERSION)-*.src.rpm
+	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 0" -D "commit $(COMMIT)" -D "commit_date $(COMMIT_DATE)" --rebuild BUILD/SRPM/python-$(PROJECT)-$(SPEC_VERSION)-*.src.rpm
 
 srpm-release: source-release
 	mkdir -p BUILD/SRPM
@@ -82,7 +83,7 @@ srpm-release: source-release
 
 rpm-release: srpm-release
 	mkdir -p BUILD/RPM
-	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/python-$(PROJECT)-$(VERSION)-*.src.rpm
+	mock -r $(MOCK_CONFIG) --resultdir BUILD/RPM -D "rel_build 1" --rebuild BUILD/SRPM/python-$(PROJECT)-$(SPEC_VERSION)-*.src.rpm
 
 clean:
 	$(MAKE) -f $(CURDIR)/debian/rules clean || true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "aexpect"
 description = "Python library used to control interactive programs"
 readme = "README.rst"
-version = "1.8.0"
+dynamic = ["version"]
 license = {text = "GPL-2.0-or-later"}
 authors = [{name = "Aexpect developers", email = "avocado-devel@redhat.com"}]
 maintainers = [{name = "Aexpect developers", email = "avocado-devel@redhat.com"}]
@@ -44,6 +44,7 @@ include = ["aexpect*"]
 [tool.setuptools_scm]
 version_scheme = "post-release"
 local_scheme = "node-and-date"
+fallback_version = "1.8.0"
 
 [tool.black]
 line-length = 79

--- a/python-aexpect.spec
+++ b/python-aexpect.spec
@@ -37,6 +37,7 @@ Source0: %{url}/archive/%{commit}/%{gittar}
 
 BuildArch: noarch
 BuildRequires: python3-devel
+BuildRequires: python3-pip
 BuildRequires: python3-setuptools
 
 %description

--- a/python-aexpect.spec
+++ b/python-aexpect.spec
@@ -39,6 +39,7 @@ BuildArch: noarch
 BuildRequires: python3-devel
 BuildRequires: python3-pip
 BuildRequires: python3-setuptools
+BuildRequires: python3-setuptools_scm
 
 %description
 Aexpect is a python library used to control interactive applications, very
@@ -61,6 +62,7 @@ sftp, telnet, among others.
 %endif
 
 %build
+export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
 %pyproject_wheel
 
 %install


### PR DESCRIPTION
this is a follow-up after https://github.com/avocado-framework/aexpect/pull/165 which fixes the Makefile so the "make rpm" works and then contains extra commit to attempt to restore dynamic versioning for pip versions while keeping hardcoded one for RPMs.

@pevogam please try this out I hope it'll work for you as well as for me. My main problem with the current version is that any issue reported will only contain the hardcoded version but we will not know whether it was released, development or even custom dirty version. I'd really like to have some dynamic versioning in-place.