### PR TITLE
pyproject: Revert the required setuptools to >=61.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=83.0.0", "setuptools-scm>=8"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
while bumping the setuptools for testing we also increased our minimal setuptools for deployment, which is not required and blocks deployment on python <3.10 which we still support. Revert the minimum back to the 61.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compatibility with environments using older supported versions of the build tooling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->